### PR TITLE
[sailfish-components-webview] Add linkClicked signal. Contributes to JB#36016

### DIFF
--- a/components/WebView.qml
+++ b/components/WebView.qml
@@ -15,12 +15,16 @@ import Sailfish.WebView 1.0
 
 RawWebView {
     id: webview
+
+    signal linkClicked(string url)
+
     active: true
 
     onViewInitialized: {
         webview.loadFrameScript("chrome://embedlite/content/embedhelper.js");
         webview.loadFrameScript("chrome://embedlite/content/SelectAsyncHelper.js");
         webview.addMessageListeners([
+            "embed:linkclicked",
             "embed:filepicker",
             "embed:selectasync",
             "embed:alert",
@@ -34,6 +38,10 @@ RawWebView {
         var webView = webview
         var dialog = null
         switch(message) {
+            case "embed:linkclicked": {
+                webview.linkClicked(data.uri)
+                break
+            }
             case "embed:filepicker": {
                 filePicker.createObject(pageStack, {
                                            "pageStack": pageStack,

--- a/plugin.cpp
+++ b/plugin.cpp
@@ -12,6 +12,7 @@
 #include "plugin.h"
 
 #include <QtCore/QTimer>
+#include <QtCore/QStandardPaths>
 #include <QtQml/QQmlEngine>
 #include <QtQml/QQmlContext>
 
@@ -54,6 +55,8 @@ static QMozContext* setupMozillaContext(const QString &userAgent = QLatin1String
     } else {
         mozCtxt->setPixelRatio(envPixelRatio);
     }
+
+    mozCtxt->setProfile(QStandardPaths::writableLocation(QStandardPaths::CacheLocation));
 
     // Set various embedlite components
     mozCtxt->addComponentManifest(SAILFISHOS_WEBVIEW_MOZILLA_COMPONENTS_PATH + QString("/components/EmbedLiteBinComponents.manifest"));

--- a/plugin.cpp
+++ b/plugin.cpp
@@ -102,6 +102,11 @@ void SailfishOSWebViewPlugin::onMozillaContextInitialized()
         mozCtxt->setPref("apz.asyncscroll.throttle", QVariant::fromValue<int>(40));
         mozCtxt->setPref("apz.asyncscroll.timeout", QVariant::fromValue<int>(400));
         mozCtxt->setPref("apz.fling_stopped_threshold", QLatin1String("0.13f"));
+
+        // Don't expose any protocol handlers by default and don't warn about those.
+        mozCtxt->setPref(QStringLiteral("network.protocol-handler.external-default"), false);
+        mozCtxt->setPref(QStringLiteral("network.protocol-handler.expose-all"), false);
+        mozCtxt->setPref(QStringLiteral("network.protocol-handler.warn-external-default"), false);
     }
 }
 


### PR DESCRIPTION
All default protocol handlers are disabled by default as
navigation must be disabled within html emails.