### PR TITLE
[sailfish-components-webview] Don't relayout content while VKB animates. Contributes to JB#36163

### DIFF
--- a/import/webview/OrientationFader.qml
+++ b/import/webview/OrientationFader.qml
@@ -1,0 +1,81 @@
+/****************************************************************************
+**
+** Copyright (C) 2015-2016 Jolla Ltd.
+** Contact: Raine Makelainen <raine.makelainen@jolla.com>
+**
+****************************************************************************/
+
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import QtQuick 2.2
+import Sailfish.Silica 1.0
+
+Rectangle {
+    id: orientationFader
+
+    property alias orientationTransition: transition
+    property alias page: propertyAction.target
+    property alias fadeTarget: fadeOut.target
+    readonly property alias running: transition.running
+    property bool waitForWebContentOrientationChanged
+
+    signal contentOrientationChanged
+
+    opacity: running || waitForWebContentOrientationChanged ? 1.0 : 0.0
+
+    Behavior on opacity {
+        FadeAnimation {
+            alwaysRunToEnd: true
+            duration: 100
+        }
+    }
+
+    Transition {
+        id: transition
+
+        to: 'Portrait,Landscape,PortraitInverted,LandscapeInverted'
+        from: 'Portrait,Landscape,PortraitInverted,LandscapeInverted'
+
+        SequentialAnimation {
+            PropertyAction {
+                id: propertyAction
+                property: 'orientationTransitionRunning'
+                value: true
+            }
+
+            FadeAnimation {
+                id: fadeOut
+                to: 0
+                duration: 100
+            }
+
+            PropertyAction {
+                target: page
+                properties: 'width,height,rotation,orientation'
+            }
+
+            ScriptAction {
+                script: {
+                    // Restores the Bindings to width, height and rotation
+                    page._defaultTransition = false
+                    page._defaultTransition = true
+                    orientationFader.contentOrientationChanged()
+                }
+            }
+
+            FadeAnimation {
+                target: fadeTarget
+                to: 1
+                duration: 150
+            }
+
+            PropertyAction {
+                target: page
+                property: 'orientationTransitionRunning'
+                value: false
+            }
+        }
+    }
+}

--- a/import/webview/WebView.qml
+++ b/import/webview/WebView.qml
@@ -182,7 +182,6 @@ RawWebView {
                 break
             }
             default: {
-                console.log("unhandled async message received: " + message)
                 break
             }
         }
@@ -260,22 +259,34 @@ RawWebView {
             return null
         }
 
+        function hasWebViewPage() {
+            return (webview.webViewPage != null && webview.webViewPage != undefined)
+        }
+
         function setActiveInPage() {
             if (webview.active) {
-                if (webview.webViewPage == null || webview.webViewPage == undefined) {
+                if (!hasWebViewPage()) {
                     webview.webViewPage = helper.findParentWithProperty(webview, '__sailfish_webviewpage')
                 }
-                if (webview.webViewPage != null && webview.webViewPage != undefined) {
+
+                if (hasWebViewPage()) {
                     webview.webViewPage.activeWebView = webview
                 }
+            }
+
+            if (!hasWebViewPage()) {
+                console.warn("WebView.qml it is mandatory to declare webViewPage property to get orientation change working correctly!")
             }
         }
     }
 
     SilicaPrivate.VirtualKeyboardObserver {
         id: virtualKeyboardObserver
+
+        readonly property QtObject appWindow: helper.findParentWithProperty(webview, "__silica_applicationwindow_instance")
+
         active: webview.enabled
-        transpose: __silica_applicationwindow_instance._transpose
+        transpose: appWindow ? appWindow._transpose : false
         onImSizeChanged: {
             if (imSize > 0 && opened) {
                 webview.virtualKeyboardMargin = virtualKeyboardObserver.imSize

--- a/import/webview/WebView.qml
+++ b/import/webview/WebView.qml
@@ -11,6 +11,7 @@
 
 import QtQuick 2.0
 import Sailfish.Silica 1.0
+import Sailfish.Silica.private 1.0 as SilicaPrivate
 import Sailfish.WebView 1.0
 import Sailfish.WebView.Popups 1.0
 import Sailfish.WebView.Pickers 1.0
@@ -267,6 +268,42 @@ RawWebView {
                 if (webview.webViewPage != null && webview.webViewPage != undefined) {
                     webview.webViewPage.activeWebView = webview
                 }
+            }
+        }
+    }
+
+    SilicaPrivate.VirtualKeyboardObserver {
+        id: virtualKeyboardObserver
+        active: webview.enabled
+        transpose: __silica_applicationwindow_instance._transpose
+        onImSizeChanged: {
+            if (imSize > 0 && opened) {
+                webview.virtualKeyboardMargin = virtualKeyboardObserver.imSize
+            }
+        }
+
+        orientation: {
+            if (webview.webViewPage != null) {
+                return webview.webViewPage.orientation
+            } else if (pageStack != undefined && pageStack != null) {
+                if (pageStack.currentPage !== undefined && pageStack.currentPage !== null) {
+                    return pageStack.currentPage.orientation
+                } else {
+                    return Orientation.Portrait
+                }
+            } else {
+                return Orientation.Portrait
+            }
+        }
+
+        onOpenedChanged: {
+            if (opened) {
+                webview.virtualKeyboardMargin = virtualKeyboardObserver.panelSize
+            }
+        }
+        onClosedChanged: {
+            if (closed) {
+                webview.virtualKeyboardMargin = 0
             }
         }
     }

--- a/import/webview/WebViewPage.qml
+++ b/import/webview/WebViewPage.qml
@@ -7,6 +7,45 @@ Page {
     property var activeWebView
 
     property int __sailfish_webviewpage
+    default property alias _contentChildren: content.data
+
+    orientationTransitions: orientationFader.orientationTransition
+
+    Item {
+        id: content
+        anchors.centerIn: parent
+        width: webViewPage.width
+        height: webViewPage.height
+    }
+
+    OrientationFader {
+        id: orientationFader
+
+        visible: !!activeWebView
+        x: activeWebView ? activeWebView.x : 0
+        y: activeWebView ? activeWebView.y : 0
+        width: activeWebView ? activeWebView.width : 0
+        height: activeWebView ? activeWebView.height : 0
+
+        page: webViewPage
+        fadeTarget: content
+        color: activeWebView ? activeWebView.bgcolor : "white"
+
+        onContentOrientationChanged: {
+            // Update content size manually while virtual keyboard is open.
+            orientationFader.waitForWebContentOrientationChanged = true
+            if (activeWebView && activeWebView.virtualKeyboardMargin > 0) {
+                activeWebView.updateContentSize(Qt.size(activeWebView.width,
+                                                        (activeWebView.virtualKeyboardMargin + activeWebView.height)))
+            }
+        }
+    }
+
+    Connections {
+        target: activeWebView
+        ignoreUnknownSignals: true
+        onContentOrientationChanged: orientationFader.waitForWebContentOrientationChanged = false
+    }
 
     states: [
         State {

--- a/import/webview/plugin.h
+++ b/import/webview/plugin.h
@@ -47,8 +47,12 @@ public:
     qreal virtualKeyboardMargin() const;
     void setVirtualKeyboardMargin(qreal vkbMargin);
 
-Q_SIGNALS:
+signals:
     void virtualKeyboardMarginChanged();
+    void contentOrientationChanged(Qt::ScreenOrientation orientation);
+
+private slots:
+    void onAsyncMessage(const QString &message, const QVariant &data);
 
 private:
     qreal m_vkbMargin;

--- a/import/webview/plugin.h
+++ b/import/webview/plugin.h
@@ -38,10 +38,20 @@ public:
 class RawWebView : public QuickMozView
 {
     Q_OBJECT
+    Q_PROPERTY(qreal virtualKeyboardMargin READ virtualKeyboardMargin WRITE setVirtualKeyboardMargin NOTIFY virtualKeyboardMarginChanged)
 
 public:
     RawWebView(QQuickItem *parent = 0);
     ~RawWebView();
+
+    qreal virtualKeyboardMargin() const;
+    void setVirtualKeyboardMargin(qreal vkbMargin);
+
+Q_SIGNALS:
+    void virtualKeyboardMarginChanged();
+
+private:
+    qreal m_vkbMargin;
 };
 
 // using custom translator so it gets properly removed from qApp when engine is deleted

--- a/import/webview/qmldir
+++ b/import/webview/qmldir
@@ -3,3 +3,4 @@ plugin sailfishwebviewplugin
 WebView 1.0 WebView.qml
 WebViewFlickable 1.0 WebViewFlickable.qml
 WebViewPage 1.0 WebViewPage.qml
+OrientationFader 1.0 OrientationFader.qml

--- a/import/webview/webview.pro
+++ b/import/webview/webview.pro
@@ -17,11 +17,11 @@ LIBS += -L../../lib -lsailfishwebengine
 
 HEADERS += plugin.h
 SOURCES += plugin.cpp
-OTHER_FILES += qmldir WebView.qml WebViewFlickable.qml WebViewPage.qml
+OTHER_FILES += qmldir *.qml
 
 include(translations.pri)
 
-import.files = qmldir WebView.qml WebViewFlickable.qml WebViewPage.qml
+import.files = qmldir *.qml
 import.path = $$TARGETPATH
 target.path = $$TARGETPATH
 

--- a/rpm/sailfish-components-webview.spec
+++ b/rpm/sailfish-components-webview.spec
@@ -77,9 +77,7 @@ Development package which provides libsailfishwebengine
 %{_libdir}/qt5/qml/Sailfish/WebEngine/qmldir
 %{_libdir}/qt5/qml/Sailfish/WebView/libsailfishwebviewplugin.so
 %{_libdir}/qt5/qml/Sailfish/WebView/qmldir
-%{_libdir}/qt5/qml/Sailfish/WebView/WebView.qml
-%{_libdir}/qt5/qml/Sailfish/WebView/WebViewFlickable.qml
-%{_libdir}/qt5/qml/Sailfish/WebView/WebViewPage.qml
+%{_libdir}/qt5/qml/Sailfish/WebView/*.qml
 
 %files ts-devel
 %defattr(-,root,root,-)
@@ -90,34 +88,14 @@ Development package which provides libsailfishwebengine
 %{_datadir}/translations/sailfish_components_webview_popups_qt5_eng_en.qm
 %{_libdir}/qt5/qml/Sailfish/WebView/Popups/libsailfishwebviewpopupsplugin.so
 %{_libdir}/qt5/qml/Sailfish/WebView/Popups/qmldir
-%{_libdir}/qt5/qml/Sailfish/WebView/Popups/UserPrompt.qml
-%{_libdir}/qt5/qml/Sailfish/WebView/Popups/AlertDialog.qml
-%{_libdir}/qt5/qml/Sailfish/WebView/Popups/AuthDialog.qml
-%{_libdir}/qt5/qml/Sailfish/WebView/Popups/ConfirmDialog.qml
-%{_libdir}/qt5/qml/Sailfish/WebView/Popups/LocationDialog.qml
-%{_libdir}/qt5/qml/Sailfish/WebView/Popups/PasswordManagerDialog.qml
-%{_libdir}/qt5/qml/Sailfish/WebView/Popups/PromptDialog.qml
-%{_libdir}/qt5/qml/Sailfish/WebView/Popups/PromptLabel.qml
-%{_libdir}/qt5/qml/Sailfish/WebView/Popups/ContextMenu.qml
-%{_libdir}/qt5/qml/Sailfish/WebView/Popups/DownloadMenuItem.qml
-%{_libdir}/qt5/qml/Sailfish/WebView/Popups/ShareLinkPage.qml
+%{_libdir}/qt5/qml/Sailfish/WebView/Popups/*.qml
 
 %files pickers
 %defattr(-,root,root,-)
 %{_datadir}/translations/sailfish_components_webview_pickers_qt5_eng_en.qm
 %{_libdir}/qt5/qml/Sailfish/WebView/Pickers/libsailfishwebviewpickersplugin.so
 %{_libdir}/qt5/qml/Sailfish/WebView/Pickers/qmldir
-%{_libdir}/qt5/qml/Sailfish/WebView/Pickers/MultiSelectDialog.qml
-%{_libdir}/qt5/qml/Sailfish/WebView/Pickers/SingleSelectPage.qml
-%{_libdir}/qt5/qml/Sailfish/WebView/Pickers/PickerCreator.qml
-%{_libdir}/qt5/qml/Sailfish/WebView/Pickers/ContentPicker.qml
-%{_libdir}/qt5/qml/Sailfish/WebView/Pickers/ImagePicker.qml
-%{_libdir}/qt5/qml/Sailfish/WebView/Pickers/MusicPicker.qml
-%{_libdir}/qt5/qml/Sailfish/WebView/Pickers/VideoPicker.qml
-%{_libdir}/qt5/qml/Sailfish/WebView/Pickers/MultiContentPicker.qml
-%{_libdir}/qt5/qml/Sailfish/WebView/Pickers/MultiImagePicker.qml
-%{_libdir}/qt5/qml/Sailfish/WebView/Pickers/MultiMusicPicker.qml
-%{_libdir}/qt5/qml/Sailfish/WebView/Pickers/MultiVideoPicker.qml
+%{_libdir}/qt5/qml/Sailfish/WebView/Pickers/*.qml
 
 %files popups-ts-devel
 %defattr(-,root,root,-)


### PR DESCRIPTION
This commit adds a virtual keyboard observer to the WebView to ensure
that we don't relayout its content while the VKB animates.

Contributes to JB#36163
