### PR TITLE
Make Flickable and WebView get along.

### DIFF
--- a/import/webview/WebView.qml
+++ b/import/webview/WebView.qml
@@ -58,6 +58,7 @@ RawWebView {
     active: true
     onActiveChanged: webview._setActiveInPage()
     Component.onCompleted: webview._setActiveInPage()
+
     onViewInitialized: {
         webview.loadFrameScript("chrome://embedlite/content/embedhelper.js");
         webview.loadFrameScript("chrome://embedlite/content/SelectAsyncHelper.js");

--- a/import/webview/WebViewFlickable.qml
+++ b/import/webview/WebViewFlickable.qml
@@ -1,85 +1,53 @@
 import QtQuick 2.1
 import Sailfish.Silica 1.0
+import Sailfish.Silica.private 1.0 as SilicaPrivate
 import Sailfish.WebView 1.0
 
-SilicaFlickable {
-    id: flickable
+Item {
+    property alias webView: webView
 
-    boundsBehavior: Flickable.DragOverBounds
-    interactive: (flickable.pullDownMenu != null && flickable.pullDownMenu.active)
-              || (flickable.pushUpMenu != null && flickable.pushUpMenu.active)
-              || ((flickTimer.showPullDownMenu || flickTimer.showPushUpMenu) && verticalVelocity <= 0 && !flickTimer.running)
+    // TODO: add header once WebView::setMargins() works
+    property alias footer: footerLoader.sourceComponent
+    property Item footerItem: footerLoader.item
 
-    onVerticalVelocityChanged: {
-        if (!flickTimer.running
-                && verticalVelocity != 0
-                && (flickable.pullDownMenu == null || !flickable.pullDownMenu.active)
-                && (flickable.pushUpMenu == null || !flickable.pushUpMenu.active)) {
-            // This is triggered when the pulley menu is interactive, but the user is
-            // attempting to pan the webview "away" from the pulley menu.
-            // (That is, either the current location is the top, and therefore the
-            // pull-down menu is interactive, but the user has attempted to pan downards,
-            // or the current location is the bottom, and therefore the push-up menu is
-            // interactive, but the user has attempted to pan upwards.)
-            //
-            // In this case, we would ideally like to "pass" the touch event directly
-            // to the WebView to handle as a panning gesture.  However, I don't know
-            // how to get the touch coordinate from the Flickable, else I guess we
-            // could just do:
-            // if (flickTimer.webView !== null) {
-            //   flickTimer.webView.synthTouchBegin([Qt.point(mouse.x,mouse.y)]);
-            // }
-            //
-            // As a hacky workaround, we disable flickable interaction for a brief
-            // period of time, giving the user a window of time within which to pan away,
-            // since touch events will not be delivered to the flickable but to the webview,
-            // however note that this requires the user to lift-finger and re-try.
-            //
-            // Note that the inverse does work properly without needing anything extra.
-            // That is, if you pan the webview to the top and then attempt to do a
-            // pull-down gesture (slowly) the pulley menu will eventually (after interactive
-            // gets reset back to "true" once the timer timeout expires) be activated,
-            // without requiring the user to lift their finger and try again.
-            // I wish that the other way around "just worked" also...
-            flickTimer.start()
-        }
-    }
+    default property alias _data: flickable.data
 
-    Timer {
-        id: flickTimer
-        interval: 1000
-        property bool showPullDownMenu: (webView == null || webView.atYBeginning) && flickable.pullDownMenu !== null
-        property bool showPushUpMenu: (webView == null || webView.atYEnd) && flickable.pushUpMenu !== null
-        onShowPullDownMenuChanged: flickable.pullDownMenu.enabled = showPullDownMenu
-        onShowPushUpMenuChanged: flickable.pushUpMenu.enabled = showPushUpMenu
+    WebView {
+        id: webView
+        width: parent.width
+        height: parent.height
+        flickable: flickable
+        bottomMargin: footerItem && footerItem.height || 0
+        clip: false
 
-        property WebView webView
-        function findChildWithProperty(item, propertyName) {
-            if ('children' in item) {
-                var children = item.children
-                for (var i in children) {
-                    var child = children[i]
-                    if (child !== null && child !== undefined) {
-                        if (child.hasOwnProperty(propertyName)) {
-                            return child
-                        } else {
-                            var possible = findChildWithProperty(child, propertyName)
-                            if (possible !== null) {
-                                return possible
-                            }
-                        }
-                    }
-                }
+        y: Math.min(Math.max(0, -flickable.contentY), flickable.contentHeight-flickable.height - flickable.contentY)
+
+        onScrollableOffsetChanged: if (!flickable.moving) flickable.contentY = scrollableOffset.y
+
+        SilicaFlickable {
+            id: flickable
+
+            y: -webView.y
+
+            width: parent.width
+            height: parent.height
+
+            contentHeight: Math.max(webView.contentHeight+webView.bottomMargin, webView.height)
+            contentWidth: width
+
+            quickScrollEnabled: false
+
+            onContentYChanged: if (flickable.moving) webView.scrollTo(webView.scrollableOffset.x, flickable.contentY)
+
+            SilicaPrivate.Wallpaper {
+                anchors.fill: footerLoader
+                verticalOffset: flickable.contentHeight - flickable.contentY - height
             }
-            return null
-        }
-        function findWebView() {
-            if (flickTimer.webView === null) {
-                flickTimer.webView = flickTimer.findChildWithProperty(flickable, "__sailfish_webview")
+            Loader {
+                id: footerLoader
+                width: flickable.width
+                y: Math.ceil(webView.y + flickable.contentHeight - height + (flickable.contentY - webView.scrollableOffset.y))
             }
         }
     }
-
-    onChildrenChanged: flickTimer.findWebView()
-    Component.onCompleted: flickTimer.findWebView()
 }

--- a/import/webview/plugin.h
+++ b/import/webview/plugin.h
@@ -16,7 +16,6 @@
 #include <QtCore/QLocale>
 
 #include <QtQml/QQmlExtensionPlugin>
-#include <QtQuick/QQuickItem>
 
 //mozembedlite-qt5
 #include <quickmozview.h>
@@ -33,29 +32,6 @@ class SailfishOSWebViewPlugin : public QQmlExtensionPlugin
 public:
     void registerTypes(const char *uri);
     void initializeEngine(QQmlEngine *engine, const char *uri);
-};
-
-class RawWebView : public QuickMozView
-{
-    Q_OBJECT
-    Q_PROPERTY(qreal virtualKeyboardMargin READ virtualKeyboardMargin WRITE setVirtualKeyboardMargin NOTIFY virtualKeyboardMarginChanged)
-
-public:
-    RawWebView(QQuickItem *parent = 0);
-    ~RawWebView();
-
-    qreal virtualKeyboardMargin() const;
-    void setVirtualKeyboardMargin(qreal vkbMargin);
-
-signals:
-    void virtualKeyboardMarginChanged();
-    void contentOrientationChanged(Qt::ScreenOrientation orientation);
-
-private slots:
-    void onAsyncMessage(const QString &message, const QVariant &data);
-
-private:
-    qreal m_vkbMargin;
 };
 
 // using custom translator so it gets properly removed from qApp when engine is deleted

--- a/import/webview/rawwebview.cpp
+++ b/import/webview/rawwebview.cpp
@@ -1,0 +1,298 @@
+/****************************************************************************
+**
+** Copyright (C) 2016 Jolla Ltd.
+** Contact: Martin Jones <martin.jones@jollamobile.com>
+**
+****************************************************************************/
+
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+#include "rawwebview.h"
+
+#include "webengine.h"
+#include "webenginesettings.h"
+
+#include <QtGui/QGuiApplication>
+#include <QtGui/QScreen>
+#include <QtGui/QStyleHints>
+#include <QtGui/QMouseEvent>
+#include <QtQuick/QQuickWindow>
+#include <private/qquickwindow_p.h>
+
+#define CONTENT_ORIENTATION_CHANGED QLatin1String("embed:contentOrientationChanged")
+
+namespace SailfishOS {
+
+namespace WebView {
+
+RawWebView::RawWebView(QQuickItem *parent)
+    : QuickMozView(parent)
+    , m_vkbMargin(0.0)
+    , m_flickable(0)
+    , m_topMargin(0)
+    , m_bottomMargin(0)
+{
+    addMessageListener(CONTENT_ORIENTATION_CHANGED);
+
+    connect(qGuiApp->inputMethod(), &QInputMethod::visibleChanged, this, [=]() {
+        if (qGuiApp->inputMethod()->isVisible()) {
+            setFollowItemGeometry(false);
+        }
+    });
+
+    connect(this, &QuickMozView::recvAsyncMessage, this, &RawWebView::onAsyncMessage);
+
+    setFiltersChildMouseEvents(true);
+}
+
+RawWebView::~RawWebView()
+{
+}
+
+qreal RawWebView::virtualKeyboardMargin() const
+{
+    return m_vkbMargin;
+}
+
+void RawWebView::setVirtualKeyboardMargin(qreal vkbMargin)
+{
+    if (m_vkbMargin != vkbMargin) {
+        m_vkbMargin = vkbMargin;
+        updateMargins();
+        emit virtualKeyboardMarginChanged();
+
+        QVariantMap map;
+        map.insert("imOpen", m_vkbMargin > 0);
+        map.insert("pixelRatio", SailfishOS::WebEngineSettings::instance()->pixelRatio());
+        map.insert("bottomMargin", m_vkbMargin);
+        // These map to max css composition size. Item's geometry might update right after this
+        // meaning that height() + m_vkbMargin doesn't yet equal to available max space.
+        // Nevertheless, it is not a big deal if we loose a pixel or two from
+        // max composition size.
+        map.insert("screenWidth", width());
+        map.insert("screenHeight", (height() + m_vkbMargin));
+        QVariant data(map);
+        sendAsyncMessage("embedui:vkbOpenCompositionMetrics", data);
+
+        if (m_vkbMargin == 0) {
+            setFollowItemGeometry(true);
+        }
+    }
+}
+
+QQuickItem *RawWebView::flickable() const
+{
+    return m_flickable;
+}
+
+void RawWebView::setFlickable(QQuickItem *flickable)
+{
+    // TODO: currently unneeded. We could replace some QML bindings with C++ handlers.
+    if (m_flickable != flickable) {
+        m_flickable = flickable;
+        if (m_flickable) {
+        }
+        emit flickableChanged();
+    }
+}
+
+qreal RawWebView::topMargin() const
+{
+    return m_topMargin;
+}
+
+void RawWebView::setTopMargin(qreal margin)
+{
+    if (margin != m_topMargin) {
+        m_topMargin = margin;
+        updateMargins();
+        emit topMarginChanged();
+    }
+}
+
+qreal RawWebView::bottomMargin() const
+{
+    return m_bottomMargin;
+}
+
+void RawWebView::setBottomMargin(qreal margin)
+{
+    if (margin != m_bottomMargin) {
+        m_bottomMargin = margin;
+        updateMargins();
+        emit bottomMarginChanged();
+    }
+}
+
+void RawWebView::updateMargins()
+{
+    setMargins(QMargins(0, m_topMargin, 0, m_bottomMargin+m_vkbMargin));
+}
+
+int RawWebView::findTouch(int id) const
+{
+    auto it = std::find_if(m_touchPoints.begin(), m_touchPoints.end(), [id](const QTouchEvent::TouchPoint& tp) { return tp.id() == id; });
+    return it != m_touchPoints.end() ? it - m_touchPoints.begin() : -1;
+}
+
+void RawWebView::clearTouch()
+{
+    setKeepMouseGrab(false);
+    setKeepTouchGrab(false);
+    m_touchPoints.clear();
+}
+
+void RawWebView::touchEvent(QTouchEvent *event)
+{
+    handleTouchEvent(event);
+    event->setAccepted(true);
+}
+
+void RawWebView::handleTouchEvent(QTouchEvent *event)
+{
+    if (event->type() == QEvent::TouchCancel) {
+        QuickMozView::touchEvent(event);
+        clearTouch();
+        return;
+    }
+
+    QQuickWindow *win = window();
+    QQuickItem *grabber = win ? win->mouseGrabberItem() : 0;
+
+    if (grabber && grabber != this && grabber->keepMouseGrab()) {
+        if (!m_touchPoints.isEmpty()) {
+            QTouchEvent localEvent(QEvent::TouchCancel);
+            localEvent.setTouchPoints(m_touchPoints);
+            QuickMozView::touchEvent(&localEvent);
+            clearTouch();
+        }
+        return;
+    }
+
+    Qt::TouchPointStates touchStates = 0;
+    QList<int> removedTouches;
+
+    const QList<QTouchEvent::TouchPoint> &touchPoints = event->touchPoints();
+    foreach (QTouchEvent::TouchPoint touchPoint, touchPoints) {
+
+        int touchIdx = findTouch(touchPoint.id());
+        if (touchIdx >= 0)
+            m_touchPoints[touchIdx] = touchPoint;
+
+        switch (touchPoint.state()) {
+        case Qt::TouchPointPressed:
+            if (touchIdx >= 0)
+                continue;
+            touchStates |= Qt::TouchPointPressed;
+            m_touchPoints.append(touchPoint);
+            if (m_touchPoints.count() > 1) {
+                setKeepMouseGrab(true);
+                setKeepTouchGrab(true);
+                grabMouse();
+                grabTouchPoints(QVector<int>() << touchPoint.id());
+            } else {
+                m_startPos = touchPoint.scenePos();
+                setKeepMouseGrab(false);
+                setKeepTouchGrab(false);
+            }
+            break;
+        // fall through
+        case Qt::TouchPointMoved: {
+            if (touchIdx < 0)
+                continue;
+            if (QQuickWindowPrivate::get(win)->touchMouseId == touchPoint.id()) {
+                const int dragThreshold = QGuiApplication::styleHints()->startDragDistance();
+                QPointF delta = touchPoint.scenePos() - m_startPos;
+                if (!keepMouseGrab()) {
+                    if ((delta.y() >= dragThreshold && !atYBeginning()) || (delta.y() <= -dragThreshold && !atYEnd())
+                            || (delta.x() >= dragThreshold && !atXBeginning()) || (delta.x() <= -dragThreshold && !atXEnd())) {
+                        setKeepMouseGrab(true);
+                        setKeepTouchGrab(true);
+                        grabMouse();
+                        grabTouchPoints(QVector<int>() << touchPoint.id());
+                    }
+                    // Do not pass this event through
+                    return;
+                } else if (grabber && grabber != this && grabber->keepMouseGrab()) {
+                    m_touchPoints.removeAt(touchIdx);
+                    event->ignore();
+                    return;
+                }
+            }
+            touchStates |= Qt::TouchPointMoved;
+            break;
+        }
+        case Qt::TouchPointReleased: {
+            if (touchIdx < 0)
+                continue;
+            touchStates |= Qt::TouchPointReleased;
+            removedTouches << touchPoint.id();
+            break;
+        }
+        default:
+            break;
+        }
+    }
+
+    if (m_touchPoints.isEmpty())
+        return;
+
+    QTouchEvent localEvent(*event);
+    localEvent.setTouchPoints(m_touchPoints);
+    localEvent.setTouchPointStates(touchStates);
+    QuickMozView::touchEvent(&localEvent);
+    event->setAccepted(localEvent.isAccepted());
+
+    foreach (int id, removedTouches) {
+        int touchIdx = findTouch(id);
+        if (touchIdx >= 0) {
+            m_touchPoints.removeAt(touchIdx);
+        }
+    }
+
+    if (m_touchPoints.isEmpty())
+        clearTouch();
+}
+
+bool RawWebView::childMouseEventFilter(QQuickItem *i, QEvent *e)
+{
+    if (!isVisible())
+        return QQuickItem::childMouseEventFilter(i, e);
+    switch (e->type()) {
+    case QEvent::TouchBegin:
+    case QEvent::TouchUpdate:
+        handleTouchEvent(static_cast<QTouchEvent*>(e));
+        e->setAccepted(keepMouseGrab());
+        return keepMouseGrab();
+    case QEvent::TouchEnd:
+        handleTouchEvent(static_cast<QTouchEvent*>(e));
+        break;
+    default:
+        break;
+    }
+
+    return QQuickItem::childMouseEventFilter(i, e);
+}
+
+void RawWebView::onAsyncMessage(const QString &message, const QVariant &data)
+{
+    if (message == CONTENT_ORIENTATION_CHANGED) {
+        QString orientation = data.toMap().value("orientation").toString();
+        Qt::ScreenOrientation mappedOrientation = Qt::PortraitOrientation;
+        if (orientation == QStringLiteral("landscape-primary")) {
+            mappedOrientation = Qt::LandscapeOrientation;
+        } else if (orientation == QStringLiteral("landscape-secondary")) {
+            mappedOrientation = Qt::InvertedLandscapeOrientation;
+        } else if (orientation == QStringLiteral("portrait-secondary")) {
+            mappedOrientation = Qt::InvertedPortraitOrientation;
+        }
+        emit contentOrientationChanged(mappedOrientation);
+    }
+}
+
+} // namespace WebView
+
+} // namespace SailfishOS
+

--- a/import/webview/rawwebview.h
+++ b/import/webview/rawwebview.h
@@ -1,0 +1,81 @@
+/****************************************************************************
+**
+** Copyright (C) 2016 Jolla Ltd.
+** Contact: Martin Jones <martin.jones@jollamobile.com>
+**
+****************************************************************************/
+
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+#ifndef SAILFISHOS_WEBVIEW_H
+#define SAILFISHOS_WEBVIEW_H
+
+#include <QtQuick/QQuickItem>
+
+//mozembedlite-qt5
+#include <quickmozview.h>
+
+namespace SailfishOS {
+
+namespace WebView {
+
+class RawWebView : public QuickMozView
+{
+    Q_OBJECT
+    Q_PROPERTY(qreal virtualKeyboardMargin READ virtualKeyboardMargin WRITE setVirtualKeyboardMargin NOTIFY virtualKeyboardMarginChanged)
+    Q_PROPERTY(QQuickItem *flickable READ flickable WRITE setFlickable NOTIFY flickableChanged FINAL)
+    Q_PROPERTY(qreal topMargin READ topMargin WRITE setTopMargin NOTIFY topMarginChanged)
+    Q_PROPERTY(qreal bottomMargin READ bottomMargin WRITE setBottomMargin NOTIFY bottomMarginChanged)
+
+public:
+    RawWebView(QQuickItem *parent = 0);
+    ~RawWebView();
+
+    qreal virtualKeyboardMargin() const;
+    void setVirtualKeyboardMargin(qreal vkbMargin);
+
+    QQuickItem *flickable() const;
+    void setFlickable(QQuickItem *flickable);
+
+    qreal topMargin() const;
+    void setTopMargin(qreal margin);
+
+    qreal bottomMargin() const;
+    void setBottomMargin(qreal margin);
+
+protected:
+    void handleTouchEvent(QTouchEvent *event);
+
+    void touchEvent(QTouchEvent *event);
+    bool childMouseEventFilter(QQuickItem *i, QEvent *e);
+
+signals:
+    void virtualKeyboardMarginChanged();
+    void contentOrientationChanged(Qt::ScreenOrientation orientation);
+    void flickableChanged();
+    void topMarginChanged();
+    void bottomMarginChanged();
+
+private slots:
+    void onAsyncMessage(const QString &message, const QVariant &data);
+
+private:
+    void updateMargins();
+    int findTouch(int id) const;
+    void clearTouch();
+
+    qreal m_vkbMargin;
+    QQuickItem *m_flickable;
+    QPointF m_startPos;
+    qreal m_topMargin;
+    qreal m_bottomMargin;
+    QList<QTouchEvent::TouchPoint> m_touchPoints;
+};
+
+} // namespace WebView
+
+} // namespace SailfishOS
+
+#endif // SAILFISHOS_WEBVIEW_H

--- a/import/webview/translations.pri
+++ b/import/webview/translations.pri
@@ -2,7 +2,7 @@ TS_FILE = $$OUT_PWD/sailfish_components_webview_qt5.ts
 EE_QM = $$OUT_PWD/sailfish_components_webview_qt5_eng_en.qm
 
 translations.commands += lupdate $$PWD -ts $$TS_FILE
-translations.depends = $$PWD/WebView.qml $$PWD/WebViewPage.qml
+translations.depends = $$PWD/WebView.qml
 translations.CONFIG += no_check_exist no_link
 translations.output = $$TS_FILE
 translations.input = .

--- a/import/webview/webview.pro
+++ b/import/webview/webview.pro
@@ -9,7 +9,7 @@ TARGETPATH = $$[QT_INSTALL_QML]/$$MODULENAME
 include(../../defaults.pri)
 
 CONFIG += link_pkgconfig plugin
-QT += quick
+QT += quick quick-private
 PKGCONFIG += qt5embedwidget
 
 QMAKE_CXXFLAGS += -fPIC
@@ -17,8 +17,10 @@ QMAKE_CXXFLAGS += -fPIC
 INCLUDEPATH += . src ../../lib
 LIBS += -L../../lib -lsailfishwebengine
 
-HEADERS += plugin.h
-SOURCES += plugin.cpp
+HEADERS += plugin.h \
+            rawwebview.h
+SOURCES += plugin.cpp \
+            rawwebview.cpp
 OTHER_FILES += qmldir *.qml
 
 include(translations.pri)

--- a/lib/webenginesettings.cpp
+++ b/lib/webenginesettings.cpp
@@ -60,8 +60,8 @@ void SailfishOS::WebEngineSettings::initialize()
     engineSettings->setPreference(QStringLiteral("embedlite.azpc.handle.longtap"), QVariant::fromValue<bool>(false));
     engineSettings->setPreference(QStringLiteral("embedlite.azpc.json.longtap"), QVariant::fromValue<bool>(true));
     engineSettings->setPreference(QStringLiteral("embedlite.azpc.json.viewport"), QVariant::fromValue<bool>(true));
-    engineSettings->setPreference(QStringLiteral("apz.asyncscroll.throttle"), QVariant::fromValue<int>(400));
-    engineSettings->setPreference(QStringLiteral("apz.asyncscroll.timeout"), QVariant::fromValue<int>(400));
+    engineSettings->setPreference(QStringLiteral("apz.asyncscroll.throttle"), QVariant::fromValue<int>(15));
+    engineSettings->setPreference(QStringLiteral("apz.asyncscroll.timeout"), QVariant::fromValue<int>(15));
     engineSettings->setPreference(QStringLiteral("apz.fling_stopped_threshold"), QLatin1String("0.13f"));
 
     // Make long press timeout equal to the one in Qt


### PR DESCRIPTION
This removes WebViewPage as it is not necessary. It also includes the WebView in the WebViewFlickable, so only WebViewFlickable need be declared. It is available via the `webView` property.

It supports a footer only at the moment until setMargins() successfully sets top margins.

You'll notice that the sync of the footer and the web view is way out and this is due to the `scrollableOffset` updates being really infrequent. We need to get better update frequency in order to keep them more closely synced.

An example:

```
import QtQuick 2.1
import Sailfish.Silica 1.0
import Sailfish.WebView 1.0
import Qt5Mozilla 1.0

ApplicationWindow {
    initialPage: Page {
        id: page
        anchors.fill: parent

        WebViewFlickable {
            id: flickable
            anchors.fill: parent

                webView.url: "http://www.wikipedia.org"

                footer: Rectangle {
                        height: Theme.itemSizeLarge
                        color: "transparent"
                        Label {
                                anchors.centerIn: parent
                                text: "Footer"
                        }
                }

            PullDownMenu {
                MenuItem { text: "itemOne" }
            }

            PushUpMenu {
                MenuItem { text: "itemTwo" }
            }
        }
    }
}
```
