### PR TITLE
[sailfish-components-webview] Calculate "screen size" from current geometry. Contributes to JB#36163

### DIFF
--- a/import/webview/plugin.cpp
+++ b/import/webview/plugin.cpp
@@ -105,8 +105,12 @@ void RawWebView::setVirtualKeyboardMargin(qreal vkbMargin)
         map.insert("imOpen", m_vkbMargin > 0);
         map.insert("pixelRatio", SailfishOS::WebEngineSettings::instance()->pixelRatio());
         map.insert("bottomMargin", m_vkbMargin);
-        map.insert("screenWidth", window()->width());
-        map.insert("screenHeight", window()->height());
+        // These map to max css composition size. Item's geometry might update right after this
+        // meaning that height() + m_vkbMargin doesn't yet equal to available max space.
+        // Nevertheless, it is not a big deal if we loose a pixel or two from
+        // max composition size.
+        map.insert("screenWidth", width());
+        map.insert("screenHeight", (height() + m_vkbMargin));
         QVariant data(map);
         sendAsyncMessage("embedui:vkbOpenCompositionMetrics", data);
 


### PR DESCRIPTION
Lanscape virtual keyboard handling was broken. This had nothing to
do with "date" and "time" input types that were mentioned in:

https://github.com/sailfishos/sailfish-components-webview/pull/11