### PR TITLE
[sailfish-webengine-settings] Update text selection background color. Fixes JB#36973

### DIFF
--- a/lib/webenginesettings.cpp
+++ b/lib/webenginesettings.cpp
@@ -64,6 +64,9 @@ void SailfishOS::WebEngineSettings::initialize()
     engineSettings->setPreference(QStringLiteral("apz.asyncscroll.timeout"), QVariant::fromValue<int>(15));
     engineSettings->setPreference(QStringLiteral("apz.fling_stopped_threshold"), QLatin1String("0.13f"));
 
+    // Theme settings.
+    engineSettings->setPreference(QStringLiteral("ui.textSelectBackground"), QLatin1String("#878787"));
+
     // Make long press timeout equal to the one in Qt
     engineSettings->setPreference(QStringLiteral("ui.click_hold_context_menus.delay"), QVariant(PressAndHoldDelay));
 


### PR DESCRIPTION
Let's do not tamper QPalette just adjust perference.

@chriadam @jpetrell review. Tested some colors with Martin Schüle and we agreed go with "#878787" that's from roughly half way between white and black. This should cope rather well possible blending cases. Of course selection background can still blend with web content but that's totally different level problem.