### PR TITLE
[sailfish-components-webview] Cleanup invisible titles. Contributes to JB#19575

### DIFF
--- a/import/pickers/MultiImagePicker.qml
+++ b/import/pickers/MultiImagePicker.qml
@@ -15,8 +15,5 @@ import Sailfish.Pickers 1.0
 MultiImagePickerDialog {
     property var creator
 
-    //: For choosing images to send to the website from the device
-    //% "Upload images"
-    title: qsTrId("sailfish_components_webview_pickers-he-upload_images")
     Component.onDestruction: creator.sendResponseList(selectedContent)
 }

--- a/import/pickers/MultiMusicPicker.qml
+++ b/import/pickers/MultiMusicPicker.qml
@@ -15,8 +15,5 @@ import Sailfish.Pickers 1.0
 MultiMusicPickerDialog {
     property var creator
 
-    //: For choosing audio files to send to the website from the device
-    //% "Upload audio files"
-    title: qsTrId("sailfish_components_webview_pickers-he-upload_audio_files")
     Component.onDestruction: creator.sendResponseList(selectedContent)
 }

--- a/import/pickers/MultiVideoPicker.qml
+++ b/import/pickers/MultiVideoPicker.qml
@@ -15,8 +15,5 @@ import Sailfish.Pickers 1.0
 MultiVideoPickerDialog {
     property var creator
 
-    //: For choosing videos to send to the website from the device
-    //% "Upload videos"
-    title: qsTrId("sailfish_components_webview_pickers-he-upload_videos")
     Component.onDestruction: creator.sendResponseList(selectedContent)
 }


### PR DESCRIPTION
These are not used as DialogHeader titles. As we have search field
visible there as well I think that it is better to cleanup title from
MultiImagePickerDialog, MultiMusicPickerDialog, and MultiVideoPickerDialog
of sailfish-components-pickers rather than adding title here as well.

@jpetrell review ?