### PR TITLE
[sailfish-components-webview] Always handle touch end. Fixes JB#37275

### DIFF
--- a/import/webview/rawwebview.cpp
+++ b/import/webview/rawwebview.cpp
@@ -45,6 +45,7 @@ RawWebView::RawWebView(QQuickItem *parent)
     connect(this, &QuickMozView::recvAsyncMessage, this, &RawWebView::onAsyncMessage);
 
     setFiltersChildMouseEvents(true);
+    qApp->installEventFilter(this);
 }
 
 RawWebView::~RawWebView()
@@ -256,6 +257,15 @@ void RawWebView::handleTouchEvent(QTouchEvent *event)
         clearTouch();
 }
 
+bool RawWebView::eventFilter(QObject *obj, QEvent *event)
+{
+    Q_UNUSED(obj);
+    if (event->type() == QEvent::TouchEnd) {
+        handleTouchEvent(static_cast<QTouchEvent*>(event));
+    }
+    return false;
+}
+
 bool RawWebView::childMouseEventFilter(QQuickItem *i, QEvent *e)
 {
     if (!isVisible())
@@ -268,6 +278,8 @@ bool RawWebView::childMouseEventFilter(QQuickItem *i, QEvent *e)
         return keepMouseGrab();
     case QEvent::TouchEnd:
         handleTouchEvent(static_cast<QTouchEvent*>(e));
+        break;
+    case QEvent::TouchCancel:
         break;
     default:
         break;

--- a/import/webview/rawwebview.h
+++ b/import/webview/rawwebview.h
@@ -48,6 +48,7 @@ public:
 protected:
     void handleTouchEvent(QTouchEvent *event);
 
+    bool eventFilter(QObject *obj, QEvent *event);
     void touchEvent(QTouchEvent *event);
     bool childMouseEventFilter(QQuickItem *i, QEvent *e);
 


### PR DESCRIPTION
When a Silica Page containing WebView is peeked and gesture is ended,
we need to reset internal state. It does not matter if ended the gesture
results that the Page being popped from the PageStack or the Page
is returned back to the active state.