### PR TITLE
Disable async scroll throttle and timeout for now

### DIFF
--- a/lib/webenginesettings.cpp
+++ b/lib/webenginesettings.cpp
@@ -19,6 +19,7 @@
 #include <QtCore/QtMath>
 #include <QtGui/QGuiApplication>
 #include <QtGui/QScreen>
+#include <QtGui/QStyleHints>
 
 Q_GLOBAL_STATIC(SailfishOS::WebEngineSettings, webEngineSettingsInstance)
 
@@ -73,6 +74,12 @@ void SailfishOS::WebEngineSettings::initialize()
 
     // Make long press timeout equal to the one in Qt
     engineSettings->setPreference(QStringLiteral("ui.click_hold_context_menus.delay"), QVariant(PressAndHoldDelay));
+
+    // DPI is passed to Gecko's View and APZTreeManager.
+    // Touch tolerance is calculated with formula: dpi * tolerance = pixel threshold
+    const int dragThreshold = QGuiApplication::styleHints()->startDragDistance();
+    qreal touchStartTolerance = dragThreshold / QGuiApplication::primaryScreen()->physicalDotsPerInch();
+    engineSettings->setPreference(QString("apz.touch_start_tolerance"), QString("%1f").arg(touchStartTolerance));
 
     Silica::Theme *silicaTheme = Silica::Theme::instance();
 

--- a/lib/webenginesettings.cpp
+++ b/lib/webenginesettings.cpp
@@ -60,8 +60,12 @@ void SailfishOS::WebEngineSettings::initialize()
     engineSettings->setPreference(QStringLiteral("embedlite.azpc.handle.longtap"), QVariant::fromValue<bool>(false));
     engineSettings->setPreference(QStringLiteral("embedlite.azpc.json.longtap"), QVariant::fromValue<bool>(true));
     engineSettings->setPreference(QStringLiteral("embedlite.azpc.json.viewport"), QVariant::fromValue<bool>(true));
+    // TODO: Fix this so that it can be applied during runtime when QQuickItem based WebView is used with QQuickFlickable.
+    // At the moment just disable it to avoid unnecessary events being fired. JB#39581
+#if 0
     engineSettings->setPreference(QStringLiteral("apz.asyncscroll.throttle"), QVariant::fromValue<int>(15));
     engineSettings->setPreference(QStringLiteral("apz.asyncscroll.timeout"), QVariant::fromValue<int>(15));
+#endif
     engineSettings->setPreference(QStringLiteral("apz.fling_stopped_threshold"), QLatin1String("0.13f"));
 
     // Theme settings.


### PR DESCRIPTION
Default values are being used instead.

See also:
https://git.merproject.org/mer-core/gecko-dev/merge_requests/42/
https://github.com/sailfishos/sailfish-browser/pull/571