### PR TITLE
[sailfish-webengine] Do not try to floor low pixel ratio values. Fixes JB#40528

### DIFF
--- a/lib/webenginesettings.cpp
+++ b/lib/webenginesettings.cpp
@@ -89,7 +89,8 @@ void SailfishOS::WebEngineSettings::initialize()
 
     int screenWidth = QGuiApplication::primaryScreen()->size().width();
 
-    if (!testScreenDimensions(pixelRatio)) {
+    // Do not floor the pixel ratio if the pixel ratio less than 2.0 (1.5 is minimum).
+    if (pixelRatio >= 2.0 && !testScreenDimensions(pixelRatio)) {
         qreal tempPixelRatio = qFloor(pixelRatio);
         if (testScreenDimensions(tempPixelRatio)) {
             pixelRatio = tempPixelRatio;


### PR DESCRIPTION
See: https://github.com/sailfishos/sailfish-browser/issues/580