### PR TITLE
Move search engine configuration to WebEngineSettings.

### DIFF
--- a/lib/lib.pro
+++ b/lib/lib.pro
@@ -3,19 +3,33 @@ TARGET = sailfishwebengine
 TARGET = $$qtLibraryTarget($$TARGET)
 TARGETPATH = $$[QT_INSTALL_LIBS]
 
+isEmpty(EMBEDLITE_CONTENT_PATH) {
+  DEFINES += EMBEDLITE_CONTENT_PATH=\"\\\"/usr/lib/mozembedlite/chrome/embedlite/content/\\\"\"
+} else {
+  DEFINES += EMBEDLITE_CONTENT_PATH=\"\\\"$$EMBEDLITE_CONTENT_PATH\\\"\"
+}
+
+isEmpty(USER_OPENSEARCH_PATH) {
+  DEFINES += USER_OPENSEARCH_PATH=\"\\\"/.local/share/org.sailfishos/sailfish-browser/searchEngines/\\\"\"
+} else {
+  DEFINES += USER_OPENSEARCH_PATH=\"\\\"$$USER_OPENSEARCH_PATH\\\"\"
+}
+
 include(../defaults.pri)
 
 CONFIG += qt create_pc create_prl no_install_prl link_pkgconfig
 QT += gui
-PKGCONFIG += qt5embedwidget sailfishsilica
+PKGCONFIG += qt5embedwidget sailfishsilica mlite5
 
 INCLUDEPATH += $$system(pkg-config --cflags sailfishsilica)
 
 SOURCES += downloadhelper.cpp \
+           opensearchconfigs.cpp \
            webengine.cpp \
            webenginesettings.cpp
 
 HEADERS += downloadhelper.h \
+           opensearchconfigs.h \
            webengine.h \
            webengine_p.h \
            webenginesettings.h \

--- a/lib/opensearchconfigs.cpp
+++ b/lib/opensearchconfigs.cpp
@@ -1,0 +1,79 @@
+/****************************************************************************
+**
+** Copyright (C) 2015
+** Contact: Siteshwar Vashisht <siteshwar@gmail.com>
+** Copyright (c) 2020 Open Mobile Platform LLC.
+**
+****************************************************************************/
+
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+
+#include <QDir>
+#include <QFile>
+#include <QXmlStreamReader>
+#include "opensearchconfigs.h"
+
+SailfishOS::OpenSearchConfigs *SailfishOS::OpenSearchConfigs::openSearchConfigs = 0;
+
+SailfishOS::OpenSearchConfigs::OpenSearchConfigs(QObject *parent)
+    : QObject(parent)
+{
+    m_openSearchPathList << QString(EMBEDLITE_CONTENT_PATH);
+    m_openSearchPathList << QDir::homePath() + USER_OPENSEARCH_PATH;
+}
+
+QMap<QString, QString> SailfishOS::OpenSearchConfigs::parseOpenSearchConfigs()
+{
+    QMap<QString, QString> configs;
+
+    foreach(QString openSearchPath, m_openSearchPathList) {
+        QDir configDir(openSearchPath);
+        configDir.setSorting(QDir::Name);
+
+        foreach (QString fileName, configDir.entryList(QStringList("*.xml"))) {
+            QFile xmlFile(openSearchPath + fileName);
+            xmlFile.open(QIODevice::ReadOnly | QIODevice::Text);
+            QXmlStreamReader xml(&xmlFile);
+            QString searchEngine;
+
+            while (!xml.atEnd()) {
+                xml.readNext();
+                if (xml.isStartElement() && xml.name() == "ShortName") {
+                    xml.readNext();
+                    if (xml.isCharacters()) {
+                        searchEngine = xml.text().toString();
+                    }
+                }
+            }
+
+            if (!xml.hasError()) {
+                configs.insert(searchEngine, openSearchPath + fileName);
+            }
+
+            xmlFile.close();
+        }
+    }
+    return configs;
+}
+
+SailfishOS::OpenSearchConfigs* SailfishOS::OpenSearchConfigs::getInstance()
+{
+    if (!openSearchConfigs) {
+        openSearchConfigs = new OpenSearchConfigs();
+    }
+    return openSearchConfigs;
+}
+
+QStringList SailfishOS::OpenSearchConfigs::getSearchEngineList()
+{
+    // Return names of search engines
+    return getInstance()->parseOpenSearchConfigs().keys();
+}
+
+QMap<QString, QString> SailfishOS::OpenSearchConfigs::getAvailableOpenSearchConfigs()
+{
+    return getInstance()->parseOpenSearchConfigs();
+}

--- a/lib/opensearchconfigs.h
+++ b/lib/opensearchconfigs.h
@@ -1,0 +1,36 @@
+/****************************************************************************
+**
+** Copyright (C) 2015
+** Contact: Siteshwar Vashisht <siteshwar@gmail.com>
+** Copyright (c) 2020 Open Mobile Platform LLC.
+**
+****************************************************************************/
+
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+
+#include <QObject>
+#include <QStringList>
+#include <QMap>
+
+namespace SailfishOS {
+
+class OpenSearchConfigs : public QObject {
+
+public:
+    static QMap<QString, QString> getAvailableOpenSearchConfigs();
+    static QStringList getSearchEngineList();
+
+private:
+    QStringList m_openSearchPathList;
+
+    inline static OpenSearchConfigs* getInstance();
+    static OpenSearchConfigs *openSearchConfigs;
+    inline QMap<QString, QString> parseOpenSearchConfigs();
+    inline QStringList parseSearchEngineList();
+    inline OpenSearchConfigs(QObject* parent=0);
+};
+
+}

--- a/lib/webenginesettings.h
+++ b/lib/webenginesettings.h
@@ -17,6 +17,7 @@
 
 namespace SailfishOS {
 
+class WebEngineSettingsPrivate;
 class WebEngineSettings : public QMozEngineSettings {
     Q_OBJECT
 public:
@@ -25,6 +26,12 @@ public:
 
     explicit WebEngineSettings(QObject *parent = 0);
     virtual ~WebEngineSettings();
+
+private:
+    QScopedPointer<WebEngineSettingsPrivate> d_ptr;
+
+    inline void setSearchEngine();
+    inline void handleObserve(const QString &message, const QVariant &data);
 };
 }
 


### PR DESCRIPTION
This is primarily about ensuring all users of the web engine fulfill the
expectations of the EmbedLiteSearchEngine.js script which will otherwise
run up against a null object and throw a Type error.