### PR TITLE
[webengine] Don't create application caches by default. Contributes to JB#48786

### DIFF
--- a/import/webengine/plugin.cpp
+++ b/import/webengine/plugin.cpp
@@ -34,7 +34,7 @@ public:
     {
         // TODO : How to deal with custom default UA. We have also means to customize
         // site specific UA overrides.
-        SailfishOS::WebEngine::initialize(QStandardPaths::writableLocation(QStandardPaths::CacheLocation));
+        SailfishOS::WebEngine::initialize(QString());
         SailfishOS::WebEngineSettings::initialize();
     }
 


### PR DESCRIPTION
The existence (or lack thereof) of a cache has a had an observed effect
on crash occurences. It's probably coincidental but it doesn't really
make sense and may even be detrimental to cache data to disk for most
web view uses which are mostly one-off transactions.