### PR TITLE
[webview] Remove "Cancel" from alert() dialogue. Contributes to JB#50018

### DIFF
--- a/import/popups/AlertDialog.qml
+++ b/import/popups/AlertDialog.qml
@@ -18,6 +18,8 @@ UserPrompt {
     //: Text on the Accept dialog button that accepts browser alert messages
     //% "Ok"
     acceptText: qsTrId("sailfish_components_webview_popups-he-accept_alert")
+    // Cancel button left blank on the alert() dialog
+    cancelText: ""
 
     PromptLabel {
         id: label

--- a/import/popups/UserPrompt.qml
+++ b/import/popups/UserPrompt.qml
@@ -15,6 +15,7 @@ import Sailfish.Silica 1.0
 Dialog {
     id: dialog
     property alias acceptText: header.acceptText
+    property alias cancelText: header.cancelText
     property alias title: header.title
 
     property var checkbox


### PR DESCRIPTION
According to W3Schools, a javascript alert() dialogue "displays an alert
box with a specified message and an OK button", in contrast with a
confirm() dialogue which also shows a Cancel button.

This change removes the "Cancel" option from the alert() dialogue.