### PR TITLE
Increase touch responsiveness

### DIFF
--- a/lib/webenginesettings.cpp
+++ b/lib/webenginesettings.cpp
@@ -128,6 +128,10 @@ void SailfishOS::WebEngineSettings::initialize()
                                   QVariant::fromValue<QString>(langs));
     engineSettings->setPreference(QStringLiteral("browser.enable_automatic_image_resizing"),
                                   QVariant::fromValue<bool>(true));
+    engineSettings->setPreference(QStringLiteral("apz.content_response_timeout"),
+                                  QVariant::fromValue<int>(600));
+    engineSettings->setPreference(QStringLiteral("layout.css.touch_action.enabled"),
+                                  QVariant::fromValue<bool>(false));
 
     isInitialized = true;
 }


### PR DESCRIPTION
Applies the following default settings:

```
apz.content_response_timeout: 600
layout.css.touch_action.enabled: false
```

This has the effect of increasing the likelihood of touch events being
passed to the correct content item, while also removing the lag when
dragging the page with a finger.