### PR TITLE
[sailfish-components-webview] Make DownloadHelper::createUniqueFileUrl more safe. Contributes to JB#50923

### DIFF
--- a/lib/downloadhelper.cpp
+++ b/lib/downloadhelper.cpp
@@ -1,6 +1,7 @@
 /****************************************************************************
 **
 ** Copyright (C) 2016 Jolla Ltd.
+** Copyright (c) 2020 Open Mobile Platform LLC.
 ** Contact: Raine Makelainen <raine.makelaine@jolla.com>
 ** Contact: Chris Adams <chris.adams@jolla.com>
 **
@@ -14,29 +15,49 @@
 
 #include <QFileInfo>
 
+constexpr int FILEEXTENSION_MAX_LENGTH = 32;
+constexpr int FILENAME_MAX_LENGTH = 255;
+
 SailfishOS::WebEngineUtils::DownloadHelper::DownloadHelper(QObject *parent)
     : QObject(parent)
 {
 }
 
-QString SailfishOS::WebEngineUtils::DownloadHelper::createUniqueFileUrl(const QString &fileName, const QString &path) const
+QString SailfishOS::WebEngineUtils::DownloadHelper::createUniqueFileUrl(QString fileName, const QString &path) const
 {
     if (path.isEmpty() || fileName.isEmpty()) {
         return QString();
     }
 
-    const QFileInfo fileInfo(fileName);
-    const QString newFile("%1/%2(%3)%4%5");
-    const QString baseName = fileInfo.baseName();
-    const QString suffix = fileInfo.completeSuffix();
+    // Replace illegal characters with dashes
+    fileName.replace(QRegExp("[<>:\"|?*%/\\\\-]+"), "-");
 
-    QString result(path + "/" + fileName);
-    int collisionCount(1);
+    // Replace whitespace characters with underscores
+    fileName.replace(QRegExp("[\\s_]+"), "_");
 
-    while (QFileInfo::exists(result)) {
-        collisionCount++;
-        result = newFile.arg(path).arg(baseName).arg(collisionCount).arg(suffix.isEmpty() ? "" : ".").arg(suffix);
+    // Replace combinations of dashes and underscores with underscores
+    fileName.replace(QRegExp("(_-|-_)+(-|_)?"), "_");
+
+    // Determine of extension position
+    int dotPosition = fileName.length();
+    for (int i = 0, j = fileName.length() - 1; i < fileName.length() && i < FILEEXTENSION_MAX_LENGTH; i++, j--) {
+        if (fileName[j] == '.') {
+            dotPosition = j;
+        }
     }
+
+    const QString baseName = fileName.left(dotPosition);
+    const QString extension = fileName.mid(dotPosition);
+
+    QString result;
+    QString suffix = extension;
+    int collisionCount = 1;
+
+    do {
+        result = QStringLiteral("%1/%2%4").arg(path).arg(baseName.left(FILENAME_MAX_LENGTH - suffix.length())).arg(suffix);
+        collisionCount++;
+        suffix = QStringLiteral("(%3)%4").arg(collisionCount).arg(extension);
+    } while (QFileInfo::exists(result));
 
     return result;
 }

--- a/lib/downloadhelper.h
+++ b/lib/downloadhelper.h
@@ -1,6 +1,7 @@
 /****************************************************************************
 **
 ** Copyright (C) 2016 Jolla Ltd.
+** Copyright (c) 2020 Open Mobile Platform LLC.
 ** Contact: Raine Makelainen <raine.makelaine@jolla.com>
 ** Contact: Chris Adams <chris.adams@jolla.com>
 **
@@ -24,7 +25,7 @@ class DownloadHelper : public QObject
     Q_OBJECT
 public:
     DownloadHelper(QObject *parent = Q_NULLPTR);
-    Q_INVOKABLE QString createUniqueFileUrl(const QString &fileName, const QString &path) const;
+    Q_INVOKABLE QString createUniqueFileUrl(QString fileName, const QString &path) const;
 };
 
 }


### PR DESCRIPTION
- Added replacement of illegal and whitespace characters with dashes and underscores;
- File name length is limited to 255 symbols;
- Added tests.