### PR TITLE
[sailfish-webview] Add ability remove all items for permission type. Contributes to JB#52493

### DIFF
--- a/import/controls/permissionfilterproxymodel.cpp
+++ b/import/controls/permissionfilterproxymodel.cpp
@@ -29,17 +29,14 @@ void PermissionFilterProxyModel::add(const QString &host, const QString &type, i
     permissionModel->add(host, type, capability);
 }
 
-void PermissionFilterProxyModel::remove(int currentIndex)
+void PermissionFilterProxyModel::remove(const QString &host, const QString &type, int capability)
 {
-    QModelIndex proxyIndex = index(currentIndex, 0);
-    QModelIndex sourceIndex = mapToSource(proxyIndex);
-
     PermissionModel *permissionModel = qobject_cast<PermissionModel *>(sourceModel());
     if (!permissionModel) {
         return;
     }
 
-    permissionModel->remove(sourceIndex.row());
+    permissionModel->remove(Permission(host, type, PermissionManager::intToCapability(capability)));
 }
 
 void PermissionFilterProxyModel::setCapability(int currentIndex, int capability)

--- a/import/controls/permissionfilterproxymodel.h
+++ b/import/controls/permissionfilterproxymodel.h
@@ -22,7 +22,7 @@ public:
     PermissionFilterProxyModel(QObject *parent = nullptr);
 
     Q_INVOKABLE void add(const QString &host, const QString &type, int capability);
-    Q_INVOKABLE void remove(int currentIndex);
+    Q_INVOKABLE void remove(const QString &host, const QString &type, int capability);
     Q_INVOKABLE void setCapability(int currentIndex, int capability);
 
     bool filterAcceptsRow(int sourceRow, const QModelIndex &sourceParent) const override;

--- a/import/controls/permissionmodel.cpp
+++ b/import/controls/permissionmodel.cpp
@@ -175,6 +175,18 @@ void PermissionModel::remove(int index)
     emit countChanged();
 }
 
+void PermissionModel::remove(const Permission &permission)
+{
+    int index = 0;
+    for (const auto &perm : m_permissionList) {
+        if (perm == permission) {
+            remove(index);
+            return;
+        }
+        index++;
+    }
+}
+
 void PermissionModel::setCapability(QModelIndex index, int capability)
 {
     if (!index.isValid() || index.row() < 0 || index.row() >= m_permissionList.count()) {
@@ -186,4 +198,17 @@ void PermissionModel::setCapability(QModelIndex index, int capability)
     PermissionManager::add(permission);
     QVector<int> roles = {Capability};
     dataChanged(index, index, roles);
+}
+
+void PermissionModel::removeAllForPermissionType(const QString &type)
+{
+    QList<Permission> permissions;
+    for (const auto &perm : m_permissionList) {
+        if (perm.m_type == type) {
+            permissions.append(perm);
+        }
+    }
+    for (const auto &perm : permissions) {
+        remove(perm);
+    }
 }

--- a/import/controls/permissionmodel.h
+++ b/import/controls/permissionmodel.h
@@ -76,8 +76,12 @@ public:
      * "desktop-notification", "popup", etc. */
     Q_INVOKABLE void add(const QString &host, const QString &type, int capability);
     Q_INVOKABLE void setCapability(QModelIndex index, int capability);
+    /* Remove all items from model for permission type.
+     * It can be "geolocation", "cookie", "popup", etc*/
+    Q_INVOKABLE void removeAllForPermissionType(const QString &type);
 
     void remove(int index);
+    void remove(const Permission &permission);
 
     QVariant data(const QModelIndex &index, int role = Qt::DisplayRole) const override;
     int rowCount(const QModelIndex &parent = QModelIndex()) const override;


### PR DESCRIPTION
Add ability to clear the proxy model by permission type.
Also, for the correct operation of deleting multiple elements, add the remove method by
host, type and capability. It fix incorrect index errors.