### PR TITLE
[components-webview] Fix saving file name with url escaping. Fixes JB#53509

### DIFF
--- a/import/popups/DownloadMenuItem.qml
+++ b/import/popups/DownloadMenuItem.qml
@@ -27,7 +27,7 @@ MenuItem {
 
         // drop query string from URL and split to sections
         var urlSections = linkUrl.split("?")[0].split("/")
-        var leafName = urlSections[urlSections.length - 1]
+        var leafName = decodeURIComponent(urlSections[urlSections.length - 1])
 
         if (leafName.length === 0) {
             leafName = "unnamed_file"


### PR DESCRIPTION
Saving file with spaces results in %20 in url. The handling here
didn't decode, but then removed % on downloadhelper.
-> saved file had spaces replaced with '20'.

Now the saved file doesn't still get spaces as the download helper
replaces whitespace with underscores, but that's a lot better already.

@rainemak 