### PR TITLE
[sailfish-components-webview] Add ability to set permission for current session. Contributes to JB#52731

### DIFF
--- a/import/controls/permissionmanager.cpp
+++ b/import/controls/permissionmanager.cpp
@@ -21,7 +21,11 @@ PermissionManager::PermissionManager(QObject *parent) : QObject(parent) {
 
 void PermissionManager::add(const Permission &permission)
 {
-    sendRequest(QStringLiteral("add"), permission.m_host, permission.m_type, permission.m_capability);
+    sendRequest(QStringLiteral("add"),
+                permission.m_host,
+                permission.m_type,
+                permission.m_capability,
+                permission.m_expireType);
 }
 
 void PermissionManager::remove(const QString &host, const QString &type)
@@ -29,21 +33,26 @@ void PermissionManager::remove(const QString &host, const QString &type)
     sendRequest(QStringLiteral("remove"), host, type);
 }
 
-void PermissionManager::add(const QString &host, const QString &type, Capability capability)
+void PermissionManager::add(const QString &host,
+                            const QString &type,
+                            Capability capability,
+                            Expiration expireType)
 {
-    add(Permission(host, type, capability));
+    add(Permission(host, type, capability, expireType));
 }
 
-void PermissionManager::sendRequest(const QString &message
-                               , const QString &host
-                               , const QString &type
-                               , Capability capability)
+void PermissionManager::sendRequest(const QString &message,
+                                    const QString &host,
+                                    const QString &type,
+                                    Capability capability,
+                                    Expiration expireType)
 {
     QVariantMap data;
     data.insert(QStringLiteral("msg"), message);
     data.insert(QStringLiteral("uri"), host);
     data.insert(QStringLiteral("type"), type);
     data.insert(QStringLiteral("permission"), QVariant::fromValue(capabilityToInt(capability)));
+    data.insert(QStringLiteral("expireType"), QVariant::fromValue(expirationToInt(expireType)));
     SailfishOS::WebEngine::instance()->notifyObservers("embedui:perms", QVariant(data));
 }
 

--- a/import/controls/permissionmanager.h
+++ b/import/controls/permissionmanager.h
@@ -40,7 +40,10 @@ public:
 
     /* Add host to exclusion list. The type property can be "geolocation", "cookie",
      * "desktop-notification", "popup", etc. */
-    Q_INVOKABLE void add(const QString &host, const QString &type, Capability capability);
+    Q_INVOKABLE void add(const QString &host,
+                         const QString &type,
+                         Capability capability,
+                         Expiration expireType = Never);
 
     // Create a PermissionManager object before using the PermissionModel
     Q_INVOKABLE void instance() {}
@@ -50,7 +53,8 @@ public:
     static void sendRequest(const QString &message,
                             const QString &host = QString(),
                             const QString &type = QString(),
-                            Capability capability = Unknown);
+                            Capability capability = Unknown,
+                            Expiration expireType = Never);
 
     static int capabilityToInt(Capability capability);
     static Capability intToCapability(int value);


### PR DESCRIPTION
Now we have popup notifications, we need to have ability to set permission for the session.
Popup differs from other permissions (ex. geolocation) we don't recieve a request and can't handle it with
checkedDontAsk response. We have to catch popup blocked events ourselves and handle it.
Therefore, adding the capabilities of the PermissionManager is required.