### PR TITLE
Signal when a login has been saved

### DIFF
--- a/import/popups/PasswordManagerDialog.qml
+++ b/import/popups/PasswordManagerDialog.qml
@@ -21,12 +21,15 @@ Dialog {
     property string notificationType
     property variant formData
 
+    signal loginSaved
+
     onAccepted: {
         contentItem.sendAsyncMessage("embedui:login",
                                    {
                                        "buttonidx": 0, // "Yes" button
                                        "id": requestId
                                    })
+        loginSaved()
     }
 
     onRejected: {

--- a/import/popups/PopupOpener.qml
+++ b/import/popups/PopupOpener.qml
@@ -46,6 +46,7 @@ Timer {
     property var topic
 
     signal aboutToOpenContextMenu(var data)
+    signal loginSaved
 
     function getCheckbox(data) {
         var inputs = data.inputs
@@ -225,10 +226,17 @@ Timer {
 
     // Open login dialog
     function login(data) {
-        pageStack.animatorPush(Qt.resolvedUrl("PasswordManagerDialog.qml"), {
+        var obj = pageStack.animatorPush(Qt.resolvedUrl("PasswordManagerDialog.qml"), {
             "contentItem": contentItem, "requestId": data.id,
             "notificationType": data.name, "formData": data.formdata
         })
+
+        obj.pageCompleted.connect(function(dialog) {
+            dialog.loginSaved.connect(function() {
+                root.loginSaved()
+            })
+        })
+
     }
 
     // Open permissions dialog


### PR DESCRIPTION
The signal is monitored by the sailfish-browser WebView, allowing it to
store favicons for pages with stored login info.

To be used alongside https://github.com/sailfishos/sailfish-browser/pull/836 .