### PR TITLE
Support translation keys in dialogs

### DIFF
--- a/doc/doc.pro
+++ b/doc/doc.pro
@@ -28,6 +28,7 @@ OTHER_FILES += \
     $$PWD/sailfish-webview-popups-locationpopupinterface.qdoc \
     $$PWD/sailfish-webview-popups-passwordmanagerpopupinterface.qdoc \
     $$PWD/sailfish-webview-popups-promptpopupinterface.qdoc \
+    $$PWD/sailfish-webview-popups-selectorpopupinterface.qdoc \
     $$PWD/sailfish-webview-popups-userpromptinterface.qdoc \
     $$PWD/sailfish-webview-popups-blockedpopupinterface.qdoc \
     $$PWD/index.qdoc

--- a/doc/index.qdoc
+++ b/doc/index.qdoc
@@ -90,6 +90,7 @@ WebView currently supports customization via the following interfaces:
 \li \l{LocationPopupInterface}
 \li \l{WebrtcPermissionInterface}
 \li \l{BlockedTabPopupInterface}
+\li \l{SelectorPopupInterface}
 \endlist
 
 */

--- a/doc/index.qdoc
+++ b/doc/index.qdoc
@@ -81,10 +81,11 @@ bound to the WebView's \c{popupProvider} property.
 
 WebView currently supports customization via the following interfaces:
 \list
+\li \l{UserPromptInterface}
+\li \l{PromptPopupInterface}
 \li \l{ContextMenuInterface}
 \li \l{AlertPopupInterface}
 \li \l{ConfirmPopupInterface}
-\li \l{PromptPopupInterface}
 \li \l{AuthPopupInterface}
 \li \l{PasswordManagerPopupInterface}
 \li \l{LocationPopupInterface}

--- a/doc/sailfish-webview-popups-alertpopupinterface.qdoc
+++ b/doc/sailfish-webview-popups-alertpopupinterface.qdoc
@@ -9,6 +9,7 @@
   \inqmlmodule Sailfish.WebView.Popups
   \ingroup sailfishos-webview-popups
   \brief A component which defines the interface for the alert popup
+  \inherits UserPromptInterface
 
   The \c{AlertPopupInterface} QML type is exposed through the
   \c{Sailfish.WebView.Popups} QML import namespace.
@@ -25,6 +26,11 @@
   Note that a custom implementation of an \c{AlertPopupInterface} need not
   offer separate accept and reject actions; simply providing an accept action
   is sufficient (e.g. an "OK" button to emit \c{accepted} when triggered).
+
+  The key assigned to \l{Sailfish.WebView.Popups::UserPromptInterface::acceptText}
+  {acceptText} will always be "OK" while
+  \l{Sailfish.WebView.Popups::UserPromptInterface::cancelText}{cancelText}
+  will always be assigned the empty string.
 
   \sa UserPromptInterface, custompopups
 */

--- a/doc/sailfish-webview-popups-authpopupinterface.qdoc
+++ b/doc/sailfish-webview-popups-authpopupinterface.qdoc
@@ -26,6 +26,37 @@
 */
 
 /*!
+  \qmlproperty var AuthPopupInterface::messageBundle
+  \brief The gecko localization bundle of the message to display to the user
+
+  A custom implementation can use this information to tailor the message
+  and details supplied to the user.
+
+  The value is either a string or an array. If it's an array then the first
+  value will be the gecko localization key taken from the commonDialogs.properties
+  file. The remaining items in the array are the parameter values to replace %1,
+  %2, etc. in the string.
+
+  If the value is a string then it will be a gecko localization key without
+  parameters.
+
+  You can search the \l{https://pontoon.mozilla.org/en-GB/firefox/}{Firefox
+  Pontoon localization database} for this file, followed by the appropriate key.
+  The key can be one of the following values:
+
+  \list
+    \li EnterLoginForRealm3
+    \li EnterLoginForProxy3
+    \li EnterUserPasswordFor2
+    \li EnterUserPasswordForCrossOrigin2
+    \li EnterPasswordFor
+  \endlist
+
+  Care must be taken as it's possible these values may change with future
+  engine updates.
+*/
+
+/*!
   \qmlproperty string AuthPopupInterface::hostname
   \brief The hostname of the site which is asking for credentials
 
@@ -117,6 +148,35 @@
   \brief The value which should be prefilled into the "remember" toggle switch
 */
 
+
+/*!
+  \qmlproperty var AuthPopupInterface::rememberMessageKey
+  \brief The gecko localization key of the message to display to the user
+         for the "remember" toggle switch
+
+  A custom implementation can use this information to tailor the message
+  shown alongside the "remember" toggle switch.
+
+  The value is either a string or an array. If it's an array then the first
+  value will be the gecko localization key taken from the commonDialogs.properties
+  file. The remaining items in the array are the parameter values to replace %1,
+  %2, etc. in the string.
+
+  If the value is a string then it will be a gecko localization key without
+  parameters.
+
+  You can search the \l{https://pontoon.mozilla.org/en-GB/firefox/}{Firefox
+  Pontoon localization database} for this file, followed by the appropriate key.
+
+  Currently there is only one value the key can take:
+
+  \list
+    \li rememberButton
+  \endlist
+
+  Care must be taken as it's possible these values may change with future
+  engine updates.
+*/
 
 /*!
   \qmlproperty string AuthPopupInterface::usernameValue

--- a/doc/sailfish-webview-popups-authpopupinterface.qdoc
+++ b/doc/sailfish-webview-popups-authpopupinterface.qdoc
@@ -9,6 +9,7 @@
   \inqmlmodule Sailfish.WebView.Popups
   \ingroup sailfishos-webview-popups
   \brief A component which defines the interface for the auth popup
+  \inherits UserPromptInterface
 
   The \c{AuthPopupInterface} QML type is exposed through the
   \c{Sailfish.WebView.Popups} QML import namespace.
@@ -21,6 +22,11 @@
   which itself extends the \l{UserPromptInterface}, and then they must
   tell the \l{WebView} to use their implementation via the \c{popupProvider}
   property.
+
+  The key assigned to \l{Sailfish.WebView.Popups::UserPromptInterface::acceptText}
+  {acceptText} will always be "AcceptLogin" while
+  \l{Sailfish.WebView.Popups::UserPromptInterface::cancelText}{cancelText}
+  will always be assigned the empty string.
 
   \sa UserPromptInterface, custompopups
 */

--- a/doc/sailfish-webview-popups-confirmpopupinterface.qdoc
+++ b/doc/sailfish-webview-popups-confirmpopupinterface.qdoc
@@ -9,6 +9,7 @@
   \inqmlmodule Sailfish.WebView.Popups
   \ingroup sailfishos-webview-popups
   \brief A component which defines the interface for the confirm popup
+  \inherits UserPromptInterface
 
   The \c{ConfirmPopupInterface} QML type is exposed through the
   \c{Sailfish.WebView.Popups} QML import namespace.
@@ -21,6 +22,16 @@
   which itself extends the \l{UserPromptInterface}, and then they must
   tell the \l{WebView} to use their implementation via the \c{popupProvider}
   property.
+
+  The keys assigned to \l{Sailfish.WebView.Popups::UserPromptInterface::acceptText}
+  {acceptText} and \l{Sailfish.WebView.Popups::UserPromptInterface::cancelText}
+  {cancelText} will always be one of "OK", "Cancel", "Yes", "No", "Save",
+  "DontSave", "Revert" or the empty string. If only DOM javascript is
+  being used, only "OK" and "Cancel" will ever be sent. A custom
+  implementation using privileged code to call functions from the
+  \l{https://developer.mozilla.org/en-US/docs/Mozilla/Tech/XPCOM/Reference/Interface/nsIPromptService}{nsIPromptService}
+  or \l{https://developer.mozilla.org/en-US/docs/Mozilla/Tech/XPCOM/Reference/Interface/nsIPrompt}{nsIPrompt}
+  interfaces has more flexibility to trigger popups which use the other keys.
 
   \sa UserPromptInterface, custompopups
 */

--- a/doc/sailfish-webview-popups-locationpopupinterface.qdoc
+++ b/doc/sailfish-webview-popups-locationpopupinterface.qdoc
@@ -9,6 +9,7 @@
   \inqmlmodule Sailfish.WebView.Popups
   \ingroup sailfishos-webview-popups
   \brief A component which defines the interface for the location permission popup
+  \inherits UserPromptInterface
 
   The \c{LocationPopupInterface} QML type is exposed through the
   \c{Sailfish.WebView.Popups} QML import namespace.

--- a/doc/sailfish-webview-popups-passwordmanagerpopupinterface.qdoc
+++ b/doc/sailfish-webview-popups-passwordmanagerpopupinterface.qdoc
@@ -28,19 +28,56 @@
   \qmlproperty string PasswordManagerPopupInterface::notificationType
   \brief The type of password operation being requested for the site
 
-  The value will be either \c{"password-save"} (if the credentials have not
+  The value will be one of \c{"password-save"} (if the credentials have not
   been seen before; the user should be asked whether they wish the webview
-  to store the credentials for them) or \c{"password-update"} (if the
+  to store the credentials for them), \c{"password-update"} (if the
   credentials have changed; the user should be asked whether they wish the
-  webview to update the stored version of the credentials).
+  webview to update the stored version of the credentials) or
+  \c{"password-update-multiuser"} (if the password is being updated but there
+  are multiple potential logins and the user must choose the correct one to
+  update).
 
   A custom implementation should display a different information message to
   the user, depending on the value of this property, to allow the user to
-  make an informed acceptance or rejection decision.
+  make an informed acceptance or rejection decision. The
+  \l{AuthPopupInterface::messageKey}(messageKey} localization key will be set
+  to a message relevant for the dialog type.
 */
 
 /*!
-  \qmlproperty variant PasswordManagerPopupInterface::formData
+  \qmlproperty var PasswordManagerPopupInterface::messageBundle
+  \brief The gecko localization key of the message to display to the user
+
+  A custom implementation can use this information to tailor the message
+  and details supplied to the user.
+
+  The value is either a string or an array. If it's an array then the first
+  value will be the gecko localization key taken from the commonDialogs.properties
+  file. The remaining items in the array are the parameter values to replace %1,
+  %2, etc. in the string.
+
+  If the value is a string then it will be a gecko localization key without
+  parameters.
+
+  You can search the \l{https://pontoon.mozilla.org/en-GB/firefox/}{Firefox
+  Pontoon localization database} for this file, followed by the appropriate key.
+
+  The key can be one of the following values:
+
+  \list
+    \li updatePasswordMsg
+    \li updatePasswordMsgNoUser
+    \li rememberPasswordMsg
+    \li rememberPasswordMsgNoUsername
+    \li passwordChangeTitle
+  \endlist
+
+  Care must be taken as it's possible these values may change with future
+  engine updates.
+*/
+
+/*!
+  \qmlproperty var PasswordManagerPopupInterface::formData
   \brief Form data associated with the credentials, including "displayUser"
          and "displayHost"
 
@@ -51,11 +88,18 @@
   For example \c{formData["displayUser"]} will contain the username associated
   with the credentials, and \c{formData["displayHost"]} will contain the name
   of the site for which the credentials are valid.
+
+  If the \l{PasswordManagerPopupInterface::notificationType}{notificationType}
+  is set to \c "password-update-multiuser" then there are multiple potential
+  usernames associated with the password being updated and the engine doesn't
+  know which to update. In this case \c formData will include the \c usernames
+  key containing an array of username. These should be presented to the user to
+  allow them to select which username to update.
 */
 
 /*!
   \internal
-  \qmlproperty variant PasswordManagerPopupInterface::_internalData
+  \qmlproperty var PasswordManagerPopupInterface::_internalData
   \brief Provides a container for the contentItem and requestId required by
          the web view.
 */

--- a/doc/sailfish-webview-popups-popupprovider.qdoc
+++ b/doc/sailfish-webview-popups-popupprovider.qdoc
@@ -122,3 +122,11 @@
   The component specified must implement the
   \l{BlockedTabPopupInterface}{blocked tab popup} interface.
 */
+
+/*!
+  \qmlproperty var PopupProvider::selectorPopup
+  \brief The selector popup component descriptor
+
+  The component specified must implement the
+  \l{SelectorPopupInterface}{selector popup} interface.
+*/

--- a/doc/sailfish-webview-popups-promptpopupinterface.qdoc
+++ b/doc/sailfish-webview-popups-promptpopupinterface.qdoc
@@ -9,6 +9,7 @@
   \inqmlmodule Sailfish.WebView.Popups
   \ingroup sailfishos-webview-popups
   \brief A component which defines the interface for the input prompt popup
+  \inherits UserPromptInterface
 
   The \c{PromptPopupInterface} QML type is exposed through the
   \c{Sailfish.WebView.Popups} QML import namespace.
@@ -21,6 +22,11 @@
   which itself extends the \l{UserPromptInterface}, and then they must
   tell the \l{WebView} to use their implementation via the \c{popupProvider}
   property.
+
+  The key assigned to \l{Sailfish.WebView.Popups::UserPromptInterface::acceptText}
+  {acceptText} will always be "OK" while the key assigned to
+  \l{Sailfish.WebView.Popups::UserPromptInterface::cancelText}{cancelText}
+  will always be "Cancel".
 
   \sa UserPromptInterface, custompopups
 */

--- a/doc/sailfish-webview-popups-selectorpopupinterface.qdoc
+++ b/doc/sailfish-webview-popups-selectorpopupinterface.qdoc
@@ -9,6 +9,7 @@
   \inqmlmodule Sailfish.WebView.Popups
   \ingroup sailfishos-webview-popups
   \brief A component which defines the interface for the item selector popup
+  \inherits UserPromptInterface
 
   The \c{SelectorPopupInterface} QML type is exposed through the
   \c{Sailfish.WebView.Popups} QML import namespace.
@@ -24,6 +25,11 @@
   which itself extends the \l{UserPromptInterface}, and then they must
   tell the \l{WebView} to use their implementation via the \c{popupComponents}
   property.
+
+  The key assigned to \l{Sailfish.WebView.Popups::UserPromptInterface::acceptText}
+  {acceptText} will always be "OK" while
+  \l{Sailfish.WebView.Popups::UserPromptInterface::cancelText}{cancelText}
+  will always be assigned the empty string.
 
   \sa UserPromptInterface, custompopups
 */

--- a/doc/sailfish-webview-popups-selectorpopupinterface.qdoc
+++ b/doc/sailfish-webview-popups-selectorpopupinterface.qdoc
@@ -1,0 +1,67 @@
+/****************************************************************************
+**
+** Copyright (c) 2021 Open Mobile Platform LLC
+**
+****************************************************************************/
+
+/*!
+  \qmltype SelectorPopupInterface
+  \inqmlmodule Sailfish.WebView.Popups
+  \ingroup sailfishos-webview-popups
+  \brief A component which defines the interface for the item selector popup
+
+  The \c{SelectorPopupInterface} QML type is exposed through the
+  \c{Sailfish.WebView.Popups} QML import namespace.
+
+  The item selector presents a dialog containing a description and a list of
+  items that can be selected by the user.
+
+  Clients who use a \l{WebView} in their application may wish to
+  customize the appearance or behavior of the item selector popup in their
+  application.
+
+  To do so, their implementation must extend the \c{SelectorPopupInterface},
+  which itself extends the \l{UserPromptInterface}, and then they must
+  tell the \l{WebView} to use their implementation via the \c{popupComponents}
+  property.
+
+  \sa UserPromptInterface, custompopups
+*/
+
+/*!
+  \qmlproperty string SelectorPopupInterface::title
+  \brief The text to display in the dialog header
+
+  A custom implementation should bind the \c{title} property of their
+  \c{DialogHeader} to the value of this property.
+*/
+
+/*!
+  \qmlproperty string SelectorPopupInterface::text
+  \brief The text to display as the alert message
+
+  A custom implementation should bind their selector text label to the value
+  of this property (for example bind it to \c{ComboBox.label} if the values are
+  being presented in the form of a \c{ComboBox}).
+*/
+
+/*!
+  \qmlproperty var SelectorPopupInterface::values
+  \brief An array of string values for the user to select from
+
+  These items should be presented to the user, for example if the values are
+  being presented in the form of a \c{ComboBox} then \c{ComboBox.model} can
+  be bound to this value.
+*/
+
+/*!
+  \qmlproperty int SelectorPopupInterface::selectedIndex
+  \brief The index of the item selected by the user
+
+  A custom implementation should bind this property to the \c{currentIndex}
+  property of their selector \c{ComboBox} (or to the appropriate property of
+  whatever selector element is being used by the custom implementation to
+  allow the user to select one of the values).
+
+  It is an output property, whose value is read by the web view.
+*/

--- a/doc/sailfish-webview-popups-userpromptinterface.qdoc
+++ b/doc/sailfish-webview-popups-userpromptinterface.qdoc
@@ -29,36 +29,67 @@
 
 /*!
   \qmlproperty string UserPromptInterface::acceptText
-  \brief The text to display for the acceptance action, if applicable
+  \brief The key of the text to display for the acceptance action, if applicable
 
-  For example, in a confirmation popup with "allow" and "deny" options,
-  the acceptText should be shown as the label on the "allow" button.
+  The possible keys that may be provided are as follows:
 
-  That is, a custom implementation should bind the \c{text} property
-  of their "allow" button to the value of this property.
+  \list
+    \li "OK"
+    \li "Cancel"
+    \li "Yes"
+    \li "No"
+    \li "Save"
+    \li "DontSave"
+    \li "Revert"
+    \li "AcceptLogin"
+    \li "" (empty string)
+  \endlist
 
-  If the web view does not provide a value for this property, the custom
-  implementation must provide its own as appropriate (e.g. a translated
-  string such as "OK" or "Allow" or "Accept").
+  For example, in a confirmation popup with "OK" and "Cancel" options,
+  an acceptText of "OK" will be passed. The label on the accept button
+  should be a suitable translation for this.
+
+  Apart from "AcceptLogin", these keys are from the commonDialogs.properties
+  gecko localization file. You can search the \l{https://pontoon.mozilla.org/en-GB/firefox/}
+  {Firefox Pontoon localization database} for this file, followed by the
+  appropriate key for appropriate translations.
+
+  It is up to the implementation to provide suitable translations; the
+  gecko translation keys should not be used directly.
+
+  The possible keys may change with future engine updates.
 */
 
 /*!
   \qmlproperty string UserPromptInterface::cancelText
-  \brief The text to display for the rejection action, if applicable
+  \brief The key of the text to display for the rejection action, if applicable
 
-  For example, in a confirmation popup with "allow" and "deny" options,
-  the cancelText should be shown as the label on the "deny" button.
+  The possible keys that may be provided are as follows:
 
-  That is, a custom implementation should bind the \c{text} property
-  of their "deny" button to the value of this property.
+  \list
+    \li "OK"
+    \li "Cancel"
+    \li "Yes"
+    \li "No"
+    \li "Save"
+    \li "DontSave"
+    \li "Revert"
+    \li "" (empty string)
+  \endlist
 
-  If the web view does not provide a value for this property, the custom
-  implementation must provide its own as appropriate (e.g. a translated
-  string such as "Cancel" or "Deny" or "Reject").
+  For example, in a confirmation popup with "OK" and "Cancel" options,
+  a cancelText of "Cancel" will be passed. The label on the cancel button
+  should be a suitable translation for this.
 
-  Note that some popup types (e.g. Alert popups) may not have any
-  rejection action, as only the accept action may be necessary, in which
-  case this property may not be required.
+  These keys are from the commonDialogs.properties gecko localization file.
+  You can search the \l{https://pontoon.mozilla.org/en-GB/firefox/}
+  {Firefox Pontoon localization database} for this file, followed by the
+  appropriate key for appropriate translations.
+
+  It is up to the implementation to provide suitable translations; the
+  gecko translation keys should not be used directly.
+
+  The possible keys may change with future engine updates.
 */
 
 /*!

--- a/import/popups/AlertDialog.qml
+++ b/import/popups/AlertDialog.qml
@@ -29,12 +29,6 @@ Dialog {
 
         anchors.fill: parent
 
-        //: Text on the Accept dialog button that accepts browser alert messages
-        //% "Ok"
-        acceptText: qsTrId("sailfish_components_webview_popups-he-accept_alert")
-        // Cancel button left blank on the alert() dialog
-        cancelText: ""
-
         UserPromptUi {
             anchors.fill: parent
             dialog: dialog

--- a/import/popups/AuthDialog.qml
+++ b/import/popups/AuthDialog.qml
@@ -50,9 +50,10 @@ Dialog {
         passwordValue: password.text
         rememberValue: remember.checked
 
+        // This key isn't provided by gecko, so we define it explicitly
         //: Text on the Accept dialog button that accepts browser's auth request
         //% "Log In"
-        acceptText: qsTrId("sailfish_components_webview_popups-he-accept_login")
+        acceptText: qsTrId("sailfish_components_webview_popups-la-accept_login")
 
         onAccepted: dialog.accept()
         onRejected: dialog.reject()

--- a/import/popups/AuthDialog.qml
+++ b/import/popups/AuthDialog.qml
@@ -11,10 +11,12 @@
 
 import QtQuick 2.0
 import Sailfish.Silica 1.0
+import "StringUtils.js" as StringUtils
 
 Dialog {
     id: dialog
 
+    property alias messageBundle: auth.messageBundle
     property alias hostname: auth.hostname
     property alias realm: auth.realm
     property alias passwordOnly: auth.passwordOnly
@@ -26,6 +28,7 @@ Dialog {
     property alias passwordPrefillValue: auth.passwordPrefillValue
     property alias rememberVisible: auth.rememberVisible
     property alias rememberPrefillValue: auth.rememberPrefillValue
+    property alias rememberMessageBundle: auth.rememberMessageBundle
 
     property alias usernameValue: auth.usernameValue
     property alias passwordValue: auth.passwordValue
@@ -65,9 +68,8 @@ Dialog {
                 Label {
                     x: Theme.horizontalPageMargin
                     width: parent.width - Theme.horizontalPageMargin * 2
-                    //: %1 is server URL, %2 is HTTP auth realm
-                    //% "The server %1 requires authentication. The server says: %2"
-                    text: qsTrId("sailfish_components_webview_popups-la-auth_requested").arg(auth.hostname).arg(auth.realm)
+                    bottomPadding: Theme.paddingLarge
+                    text: StringUtils.geckoKeyToString(auth.messageBundle)
                     wrapMode: Text.Wrap
                     color: Theme.highlightColor
                 }
@@ -109,10 +111,7 @@ Dialog {
                     // Better to hide the whole checkbox.
                     visible: !auth.privateBrowsing && !(auth.rememberVisible && auth.rememberPrefillValue)
                     checked: auth.rememberPrefillValue // bind the output value for when the prefill value is true.
-
-                    //: Remember entered credentials for later use
-                    //% "Remember credentials"
-                    text: qsTrId("sailfish_components_webview_popups-remember_credentials")
+                    text: StringUtils.geckoKeyToString(auth.rememberMessageBundle)
                 }
 
                 Label {

--- a/import/popups/AuthPopupInterface.qml
+++ b/import/popups/AuthPopupInterface.qml
@@ -13,6 +13,7 @@ import Sailfish.Silica 1.0
 
 UserPromptInterface {
     // inputs
+    property var messageBundle
     property string hostname
     property string realm
     property bool passwordOnly
@@ -24,6 +25,7 @@ UserPromptInterface {
     property string passwordPrefillValue
     property bool rememberVisible // should only be shown if rememberVisible && !privateBrowsing
     property bool rememberPrefillValue
+    property var rememberMessageBundle
 
     // outputs
     property string usernameValue

--- a/import/popups/ConfirmDialog.qml
+++ b/import/popups/ConfirmDialog.qml
@@ -29,10 +29,6 @@ Dialog {
 
         anchors.fill: parent
 
-        //: Text on the Accept dialog button that accepts browser's confirm() messages
-        //% "Ok"
-        acceptText: qsTrId("sailfish_components_webview_popups-he-accept_confirm")
-
         UserPromptUi {
             anchors.fill: parent
             dialog: dialog

--- a/import/popups/PopupOpener.qml
+++ b/import/popups/PopupOpener.qml
@@ -80,6 +80,14 @@ Timer {
         return null
     }
 
+    function getButtonStringKeys(data, defaultButtons) {
+        var buttons = data.buttons || defaultButtons;
+        while (buttons.length < defaultButtons.length) {
+            buttons.push("")
+        }
+        return buttons
+    }
+
     // Returns true if message is handled.
     function message(topic, data) {
         if (!handlesMessage(topic)) {
@@ -137,8 +145,11 @@ Timer {
     function alert(data) {
         var checkbox = getCheckbox(data)
         var winId = data.winId
+        var buttons = getButtonStringKeys(data, ["OK", ""])
         var props = {
             "text": data.text,
+            "acceptText": buttons[0],
+            "cancelText": buttons[1],
             "preventDialogsVisible": !(checkbox == null),
             "preventDialogsPrefillValue": (!(checkbox == null) ? checkbox.value : false)
         }
@@ -158,8 +169,14 @@ Timer {
     function confirm(data) {
         var checkbox = getCheckbox(data)
         var winId = data.winId
+        var buttons = getButtonStringKeys(data, ["OK", "Cancel"])
+        if (buttons.length > 2) {
+            console.log("Requesting " + buttons.length + " buttons, but only two are supported.")
+        }
         var props = {
             "text": data.text,
+            "acceptText": buttons[0],
+            "cancelText": buttons[1],
             "preventDialogsVisible": !(checkbox == null),
             "preventDialogsPrefillValue": (!(checkbox == null) ? checkbox.value : false)
         }
@@ -187,9 +204,12 @@ Timer {
     function prompt(data) {
         var checkbox = getCheckbox(data)
         var winId = data.winId
+        var buttons = getButtonStringKeys(data, ["OK", "Cancel"])
         var props = {
             "text": data.text,
             "value": data.defaultValue,
+            "acceptText": buttons[0],
+            "cancelText": buttons[1],
             "preventDialogsVisible": !(checkbox == null),
             "preventDialogsPrefillValue": (!(checkbox == null) ? checkbox.value : false)
         }
@@ -259,9 +279,12 @@ Timer {
             }
         }
         var passwordOnly = !username
+        var buttons = getButtonStringKeys(data, ["AcceptLogin", ""])
 
         var props = {
             "messageBundle": data.text,
+            "acceptText": buttons[0],
+            "cancelText": buttons[1],
             "hostname": data.hostname || "",
             "realm": data.realm || "",
             "usernameVisible": !(username == null),
@@ -389,9 +412,12 @@ Timer {
 
     function selector(data) {
         var winId = data.winId
+        var buttons = getButtonStringKeys(data, ["OK", ""])
         var props = {
             "title": data.title,
             "text": data.text,
+            "acceptText": buttons[0],
+            "cancelText": buttons[1],
             "values": getMenuList(data)
         }
 

--- a/import/popups/PopupProvider.qml
+++ b/import/popups/PopupProvider.qml
@@ -10,4 +10,5 @@ QtObject {
     property var locationPermissionPopup: ({"type": "dialog", "component": "LocationDialog.qml" })
     property var webrtcPermissionPopup: ({"type": "dialog", "component": "WebrtcPermissionDialog.qml"})
     property var blockedTabPopup: ({"type": "dialog", "component": "BlockedTabPopupDialog.qml"})
+    property var selectorPopup: ({"type": "dialog", "component": "SelectorDialog.qml"})
 }

--- a/import/popups/PromptDialog.qml
+++ b/import/popups/PromptDialog.qml
@@ -33,10 +33,6 @@ Dialog {
         anchors.fill: parent
         value: input.text
 
-        //: Text on the Accept dialog button that accepts browser's prompt() messages
-        //% "Ok"
-        acceptText: qsTrId("sailfish_components_webview_popups-he-accept_prompt")
-
         onAccepted: dialog.accept()
 
         UserPromptUi {

--- a/import/popups/SelectorDialog.qml
+++ b/import/popups/SelectorDialog.qml
@@ -1,0 +1,61 @@
+/****************************************************************************
+**
+** Copyright (c) 2021 Open Mobile Platform LLC.
+**
+****************************************************************************/
+
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import QtQuick 2.0
+import Sailfish.Silica 1.0
+
+Dialog {
+    id: dialog
+
+    canAccept: true
+
+    property alias text: prompt.text
+    property alias values: prompt.values
+    property alias selectedIndex: prompt.selectedIndex
+
+    property alias title: prompt.title
+
+    SelectorPopupInterface {
+        id: prompt
+
+        anchors.fill: parent
+        selectedIndex: selector.currentIndex
+
+        //: Accept button text on the select dialog for selecting items from a list
+        //% "Ok"
+        acceptText: qsTrId("sailfish_components_webview_popups-he-accept_select")
+        //: Reject button text on the select dialog for selecting items from a list
+        //% "Cancel"
+        cancelText: qsTrId("sailfish_components_webview_popups-he-reject_select")
+
+        onAccepted: dialog.accept()
+        onRejected: dialog.reject()
+
+        UserPromptUi {
+            anchors.fill: parent
+            dialog: dialog
+            popupInterface: prompt
+
+            ComboBox {
+                id: selector
+                label: prompt.text
+
+                menu: ContextMenu {
+                    Repeater {
+                        model: prompt.values
+                        delegate: MenuItem {
+                            text: model.modelData
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/import/popups/SelectorDialog.qml
+++ b/import/popups/SelectorDialog.qml
@@ -16,6 +16,8 @@ Dialog {
 
     canAccept: true
 
+    property alias acceptText: prompt.acceptText
+    property alias cancelText: prompt.cancelText
     property alias text: prompt.text
     property alias values: prompt.values
     property alias selectedIndex: prompt.selectedIndex
@@ -27,13 +29,6 @@ Dialog {
 
         anchors.fill: parent
         selectedIndex: selector.currentIndex
-
-        //: Accept button text on the select dialog for selecting items from a list
-        //% "Ok"
-        acceptText: qsTrId("sailfish_components_webview_popups-he-accept_select")
-        //: Reject button text on the select dialog for selecting items from a list
-        //% "Cancel"
-        cancelText: qsTrId("sailfish_components_webview_popups-he-reject_select")
 
         onAccepted: dialog.accept()
         onRejected: dialog.reject()

--- a/import/popups/SelectorPopupInterface.qml
+++ b/import/popups/SelectorPopupInterface.qml
@@ -11,17 +11,12 @@
 import QtQuick 2.0
 import Sailfish.Silica 1.0
 
-Item {
+UserPromptInterface {
     // inputs
-    property string notificationType
-    property var messageBundle
-    property var formData
-
-    // internal, don't touch this.
-    property var _internalData // contentItem and requestId
+    property string title
+    property string text
+    property var values
 
     // outputs
-    signal accepted
-    signal rejected
-    property string selectedIndex
+    property int selectedIndex
 }

--- a/import/popups/StringUtils.js
+++ b/import/popups/StringUtils.js
@@ -1,0 +1,42 @@
+
+// Convert from camelCase to snake_case
+// Must exactly match the outputs from generate_property_translations.py _convert_key()
+function _convert_key(name, prefix) {
+    prefix = (typeof prefix !== "undefined") ? prefix : "sailfish_components_webview_popups-la"
+    var snake = name.replace(/([a-z\d]+)([A-Z])/g,"$1_$2").toLowerCase()
+    return snake.length ? "%1-%2".arg(prefix).arg(snake) : ""
+}
+
+// Convert a gecko key to a translated string via a Qt translation Id
+// textBunlde is either a gecko key, or an array containing a key followed by
+// input parameters
+function geckoKeyToString(textBundle, prefix) {
+    var string
+    var bundle = (typeof textBundle !== "string")
+    var key = bundle ? textBundle[0] : textBundle
+    var id = _convert_key(key)
+    string = qsTrId(id)
+    if (string === id) {
+        // If the key has no translation, use the original gecko key instead
+        // since it may be a pre-translated string
+        string = key
+    }
+    if (bundle) {
+        for (var input = 1; input < textBundle.length; ++input) {
+            string = string.arg(textBundle[input])
+        }
+    }
+
+    return string
+}
+
+// Trim the input to the maximum and add an ellipsis (or local equivalent) if needed
+function trimInput(string, maxlen) {
+    maxlen = (typeof maxlen !== "undefined") ? maxlen : 150
+    if (string.length > maxlen) {
+        //: Used for truncating a string; %1 will be replaced with a truncted version of the original string
+        //% "%1\u2026"
+        string = qsTrId("sailfish_components_webview_popups-st-truncate").arg(string.substring(0, maxlen))
+    }
+    return string
+}

--- a/import/popups/UserPromptUi.qml
+++ b/import/popups/UserPromptUi.qml
@@ -11,6 +11,7 @@
 
 import QtQuick 2.0
 import Sailfish.Silica 1.0
+import "StringUtils.js" as StringUtils
 
 Item {
     id: root
@@ -33,8 +34,8 @@ Item {
                 id: header
                 dialog: dialog
                 _glassOnly: true
-                acceptText: popupInterface.acceptText
-                cancelText: popupInterface.cancelText
+                acceptText: StringUtils.geckoKeyToString(popupInterface.acceptText)
+                cancelText: StringUtils.geckoKeyToString(popupInterface.cancelText)
                 title: popupInterface.title
             }
 

--- a/import/popups/generated/commonDialogs.cpp
+++ b/import/popups/generated/commonDialogs.cpp
@@ -1,0 +1,152 @@
+/* Generated dummy file, do not edit */
+
+//: This is a transformed translation key, the original translation key
+//: (Alert) is from https://hg.mozilla.org/l10n-central/en-GB/file/0f3c06bd68fc99da1a2e724f5a78119f922a64cc/toolkit/chrome/global/commonDialogs.properties at line 5
+//% "Alert"
+const auto alert = qtTrId("sailfish_components_webview_popups-la-alert");
+
+//: This is a transformed translation key, the original translation key
+//: (Confirm) is from https://hg.mozilla.org/l10n-central/en-GB/file/0f3c06bd68fc99da1a2e724f5a78119f922a64cc/toolkit/chrome/global/commonDialogs.properties at line 6
+//% "Confirm"
+const auto confirm = qtTrId("sailfish_components_webview_popups-la-confirm");
+
+//: This is a transformed translation key, the original translation key
+//: (ConfirmCheck) is from https://hg.mozilla.org/l10n-central/en-GB/file/0f3c06bd68fc99da1a2e724f5a78119f922a64cc/toolkit/chrome/global/commonDialogs.properties at line 7
+//% "Confirm"
+const auto confirm_check = qtTrId("sailfish_components_webview_popups-la-confirm_check");
+
+//: This is a transformed translation key, the original translation key
+//: (Prompt) is from https://hg.mozilla.org/l10n-central/en-GB/file/0f3c06bd68fc99da1a2e724f5a78119f922a64cc/toolkit/chrome/global/commonDialogs.properties at line 8
+//% "Prompt"
+const auto prompt = qtTrId("sailfish_components_webview_popups-la-prompt");
+
+//: This is a transformed translation key, the original translation key
+//: (PromptUsernameAndPassword3) is from https://hg.mozilla.org/l10n-central/en-GB/file/0f3c06bd68fc99da1a2e724f5a78119f922a64cc/toolkit/chrome/global/commonDialogs.properties at line 10
+//% "Authentication Required - %1"
+const auto prompt_username_and_password3 = qtTrId("sailfish_components_webview_popups-la-prompt_username_and_password3");
+
+//: This is a transformed translation key, the original translation key
+//: (PromptPassword3) is from https://hg.mozilla.org/l10n-central/en-GB/file/0f3c06bd68fc99da1a2e724f5a78119f922a64cc/toolkit/chrome/global/commonDialogs.properties at line 12
+//% "Password Required - %1"
+const auto prompt_password3 = qtTrId("sailfish_components_webview_popups-la-prompt_password3");
+
+//: This is a transformed translation key, the original translation key
+//: (Select) is from https://hg.mozilla.org/l10n-central/en-GB/file/0f3c06bd68fc99da1a2e724f5a78119f922a64cc/toolkit/chrome/global/commonDialogs.properties at line 13
+//% "Select"
+const auto select = qtTrId("sailfish_components_webview_popups-la-select");
+
+//: This is a transformed translation key, the original translation key
+//: (OK) is from https://hg.mozilla.org/l10n-central/en-GB/file/0f3c06bd68fc99da1a2e724f5a78119f922a64cc/toolkit/chrome/global/commonDialogs.properties at line 14
+//% "OK"
+const auto ok = qtTrId("sailfish_components_webview_popups-la-ok");
+
+//: This is a transformed translation key, the original translation key
+//: (Cancel) is from https://hg.mozilla.org/l10n-central/en-GB/file/0f3c06bd68fc99da1a2e724f5a78119f922a64cc/toolkit/chrome/global/commonDialogs.properties at line 15
+//% "Cancel"
+const auto cancel = qtTrId("sailfish_components_webview_popups-la-cancel");
+
+//: This is a transformed translation key, the original translation key
+//: (Yes) is from https://hg.mozilla.org/l10n-central/en-GB/file/0f3c06bd68fc99da1a2e724f5a78119f922a64cc/toolkit/chrome/global/commonDialogs.properties at line 16
+//% "Yes"
+const auto yes = qtTrId("sailfish_components_webview_popups-la-yes");
+
+//: This is a transformed translation key, the original translation key
+//: (No) is from https://hg.mozilla.org/l10n-central/en-GB/file/0f3c06bd68fc99da1a2e724f5a78119f922a64cc/toolkit/chrome/global/commonDialogs.properties at line 17
+//% "No"
+const auto no = qtTrId("sailfish_components_webview_popups-la-no");
+
+//: This is a transformed translation key, the original translation key
+//: (Save) is from https://hg.mozilla.org/l10n-central/en-GB/file/0f3c06bd68fc99da1a2e724f5a78119f922a64cc/toolkit/chrome/global/commonDialogs.properties at line 18
+//% "Save"
+const auto save = qtTrId("sailfish_components_webview_popups-la-save");
+
+//: This is a transformed translation key, the original translation key
+//: (Revert) is from https://hg.mozilla.org/l10n-central/en-GB/file/0f3c06bd68fc99da1a2e724f5a78119f922a64cc/toolkit/chrome/global/commonDialogs.properties at line 19
+//% "Revert"
+const auto revert = qtTrId("sailfish_components_webview_popups-la-revert");
+
+//: This is a transformed translation key, the original translation key
+//: (DontSave) is from https://hg.mozilla.org/l10n-central/en-GB/file/0f3c06bd68fc99da1a2e724f5a78119f922a64cc/toolkit/chrome/global/commonDialogs.properties at line 20
+//% "Don’t Save"
+const auto dont_save = qtTrId("sailfish_components_webview_popups-la-dont_save");
+
+//: This is a transformed translation key, the original translation key
+//: (ScriptDlgGenericHeading) is from https://hg.mozilla.org/l10n-central/en-GB/file/0f3c06bd68fc99da1a2e724f5a78119f922a64cc/toolkit/chrome/global/commonDialogs.properties at line 21
+//% "[JavaScript Application]"
+const auto script_dlg_generic_heading = qtTrId("sailfish_components_webview_popups-la-script_dlg_generic_heading");
+
+//: This is a transformed translation key, the original translation key
+//: (ScriptDlgHeading) is from https://hg.mozilla.org/l10n-central/en-GB/file/0f3c06bd68fc99da1a2e724f5a78119f922a64cc/toolkit/chrome/global/commonDialogs.properties at line 22
+//% "The page at %1 says:"
+const auto script_dlg_heading = qtTrId("sailfish_components_webview_popups-la-script_dlg_heading");
+
+//: This is a transformed translation key, the original translation key
+//: (ScriptDlgNullPrincipalHeading) is from https://hg.mozilla.org/l10n-central/en-GB/file/0f3c06bd68fc99da1a2e724f5a78119f922a64cc/toolkit/chrome/global/commonDialogs.properties at line 23
+//% "This page says:"
+const auto script_dlg_null_principal_heading = qtTrId("sailfish_components_webview_popups-la-script_dlg_null_principal_heading");
+
+//: This is a transformed translation key, the original translation key
+//: (ScriptDialogLabel) is from https://hg.mozilla.org/l10n-central/en-GB/file/0f3c06bd68fc99da1a2e724f5a78119f922a64cc/toolkit/chrome/global/commonDialogs.properties at line 24
+//% "Prevent this page from creating additional dialogues"
+const auto script_dialog_label = qtTrId("sailfish_components_webview_popups-la-script_dialog_label");
+
+//: This is a transformed translation key, the original translation key
+//: (ScriptDialogLabelNullPrincipal) is from https://hg.mozilla.org/l10n-central/en-GB/file/0f3c06bd68fc99da1a2e724f5a78119f922a64cc/toolkit/chrome/global/commonDialogs.properties at line 25
+//% "Don’t allow this site to prompt you again"
+const auto script_dialog_label_null_principal = qtTrId("sailfish_components_webview_popups-la-script_dialog_label_null_principal");
+
+//: This is a transformed translation key, the original translation key
+//: (ScriptDialogLabelContentPrincipal) is from https://hg.mozilla.org/l10n-central/en-GB/file/0f3c06bd68fc99da1a2e724f5a78119f922a64cc/toolkit/chrome/global/commonDialogs.properties at line 29
+//% "Don’t allow %1 to prompt you again"
+const auto script_dialog_label_content_principal = qtTrId("sailfish_components_webview_popups-la-script_dialog_label_content_principal");
+
+//: This is a transformed translation key, the original translation key
+//: (ScriptDialogPreventTitle) is from https://hg.mozilla.org/l10n-central/en-GB/file/0f3c06bd68fc99da1a2e724f5a78119f922a64cc/toolkit/chrome/global/commonDialogs.properties at line 30
+//% "Confirm Dialogue Preference"
+const auto script_dialog_prevent_title = qtTrId("sailfish_components_webview_popups-la-script_dialog_prevent_title");
+
+//: This is a transformed translation key, the original translation key
+//: (EnterLoginForRealm3) is from https://hg.mozilla.org/l10n-central/en-GB/file/0f3c06bd68fc99da1a2e724f5a78119f922a64cc/toolkit/chrome/global/commonDialogs.properties at line 36
+//% "%2 is requesting your username and password. The site says: “%1”"
+const auto enter_login_for_realm3 = qtTrId("sailfish_components_webview_popups-la-enter_login_for_realm3");
+
+//: This is a transformed translation key, the original translation key
+//: (EnterLoginForProxy3) is from https://hg.mozilla.org/l10n-central/en-GB/file/0f3c06bd68fc99da1a2e724f5a78119f922a64cc/toolkit/chrome/global/commonDialogs.properties at line 37
+//% "The proxy %2 is requesting a username and password. The site says: “%1”"
+const auto enter_login_for_proxy3 = qtTrId("sailfish_components_webview_popups-la-enter_login_for_proxy3");
+
+//: This is a transformed translation key, the original translation key
+//: (EnterUserPasswordFor2) is from https://hg.mozilla.org/l10n-central/en-GB/file/0f3c06bd68fc99da1a2e724f5a78119f922a64cc/toolkit/chrome/global/commonDialogs.properties at line 38
+//% "%1 is requesting your username and password."
+const auto enter_user_password_for2 = qtTrId("sailfish_components_webview_popups-la-enter_user_password_for2");
+
+//: This is a transformed translation key, the original translation key
+//: (EnterUserPasswordForCrossOrigin2) is from https://hg.mozilla.org/l10n-central/en-GB/file/0f3c06bd68fc99da1a2e724f5a78119f922a64cc/toolkit/chrome/global/commonDialogs.properties at line 39
+//% "%1 is requesting your username and password. WARNING: Your password will not be sent to the web site you are currently visiting!"
+const auto enter_user_password_for_cross_origin2 = qtTrId("sailfish_components_webview_popups-la-enter_user_password_for_cross_origin2");
+
+//: This is a transformed translation key, the original translation key
+//: (EnterPasswordFor) is from https://hg.mozilla.org/l10n-central/en-GB/file/0f3c06bd68fc99da1a2e724f5a78119f922a64cc/toolkit/chrome/global/commonDialogs.properties at line 40
+//% "Enter password for %1 on %2"
+const auto enter_password_for = qtTrId("sailfish_components_webview_popups-la-enter_password_for");
+
+//: This is a transformed translation key, the original translation key
+//: (EnterCredentials) is from https://hg.mozilla.org/l10n-central/en-GB/file/0f3c06bd68fc99da1a2e724f5a78119f922a64cc/toolkit/chrome/global/commonDialogs.properties at line 41
+//% "This site is asking you to sign in."
+const auto enter_credentials = qtTrId("sailfish_components_webview_popups-la-enter_credentials");
+
+//: This is a transformed translation key, the original translation key
+//: (EnterPasswordOnlyFor) is from https://hg.mozilla.org/l10n-central/en-GB/file/0f3c06bd68fc99da1a2e724f5a78119f922a64cc/toolkit/chrome/global/commonDialogs.properties at line 43
+//% "This site is asking you to sign in as %1."
+const auto enter_password_only_for = qtTrId("sailfish_components_webview_popups-la-enter_password_only_for");
+
+//: This is a transformed translation key, the original translation key
+//: (EnterCredentialsCrossOrigin) is from https://hg.mozilla.org/l10n-central/en-GB/file/0f3c06bd68fc99da1a2e724f5a78119f922a64cc/toolkit/chrome/global/commonDialogs.properties at line 45
+//% "This site is asking you to sign in. Warning: Your login information will be shared with %1, not the web site you are currently visiting."
+const auto enter_credentials_cross_origin = qtTrId("sailfish_components_webview_popups-la-enter_credentials_cross_origin");
+
+//: This is a transformed translation key, the original translation key
+//: (SignIn) is from https://hg.mozilla.org/l10n-central/en-GB/file/0f3c06bd68fc99da1a2e724f5a78119f922a64cc/toolkit/chrome/global/commonDialogs.properties at line 46
+//% "Sign in"
+const auto sign_in = qtTrId("sailfish_components_webview_popups-la-sign_in");
+/* End of translations */

--- a/import/popups/generated/passwordmgr.cpp
+++ b/import/popups/generated/passwordmgr.cpp
@@ -1,0 +1,182 @@
+/* Generated dummy file, do not edit */
+
+//: This is a transformed translation key, the original translation key
+//: (rememberPassword) is from https://hg.mozilla.org/l10n-central/en-GB/file/0f3c06bd68fc99da1a2e724f5a78119f922a64cc/toolkit/chrome/passwordmgr/passwordmgr.properties at line 5
+//% "Use Password Manager to remember this password."
+const auto remember_password = qtTrId("sailfish_components_webview_popups-la-remember_password");
+
+//: This is a transformed translation key, the original translation key
+//: (savePasswordTitle) is from https://hg.mozilla.org/l10n-central/en-GB/file/0f3c06bd68fc99da1a2e724f5a78119f922a64cc/toolkit/chrome/passwordmgr/passwordmgr.properties at line 6
+//% "Confirm"
+const auto save_password_title = qtTrId("sailfish_components_webview_popups-la-save_password_title");
+
+//: This is a transformed translation key, the original translation key
+//: (saveLoginMsg) is from https://hg.mozilla.org/l10n-central/en-GB/file/0f3c06bd68fc99da1a2e724f5a78119f922a64cc/toolkit/chrome/passwordmgr/passwordmgr.properties at line 9
+//% "Would you like %1 to save this login for %2?"
+const auto save_login_msg = qtTrId("sailfish_components_webview_popups-la-save_login_msg");
+
+//: This is a transformed translation key, the original translation key
+//: (saveLoginMsgNoUser) is from https://hg.mozilla.org/l10n-central/en-GB/file/0f3c06bd68fc99da1a2e724f5a78119f922a64cc/toolkit/chrome/passwordmgr/passwordmgr.properties at line 10
+//% "Would you like %1 to save this password for %2?"
+const auto save_login_msg_no_user = qtTrId("sailfish_components_webview_popups-la-save_login_msg_no_user");
+
+//: This is a transformed translation key, the original translation key
+//: (saveLoginMsg2) is from https://hg.mozilla.org/l10n-central/en-GB/file/0f3c06bd68fc99da1a2e724f5a78119f922a64cc/toolkit/chrome/passwordmgr/passwordmgr.properties at line 13
+//% "Save login for %1?"
+const auto save_login_msg2 = qtTrId("sailfish_components_webview_popups-la-save_login_msg2");
+
+//: This is a transformed translation key, the original translation key
+//: (saveLoginMsgNoUser2) is from https://hg.mozilla.org/l10n-central/en-GB/file/0f3c06bd68fc99da1a2e724f5a78119f922a64cc/toolkit/chrome/passwordmgr/passwordmgr.properties at line 14
+//% "Save password for %1?"
+const auto save_login_msg_no_user2 = qtTrId("sailfish_components_webview_popups-la-save_login_msg_no_user2");
+
+//: This is a transformed translation key, the original translation key
+//: (updateLoginMsg) is from https://hg.mozilla.org/l10n-central/en-GB/file/0f3c06bd68fc99da1a2e724f5a78119f922a64cc/toolkit/chrome/passwordmgr/passwordmgr.properties at line 21
+//% "Would you like to update this login?"
+const auto update_login_msg = qtTrId("sailfish_components_webview_popups-la-update_login_msg");
+
+//: This is a transformed translation key, the original translation key
+//: (updateLoginMsgNoUser) is from https://hg.mozilla.org/l10n-central/en-GB/file/0f3c06bd68fc99da1a2e724f5a78119f922a64cc/toolkit/chrome/passwordmgr/passwordmgr.properties at line 22
+//% "Would you like to update this password?"
+const auto update_login_msg_no_user = qtTrId("sailfish_components_webview_popups-la-update_login_msg_no_user");
+
+//: This is a transformed translation key, the original translation key
+//: (updateLoginMsgAddUsername) is from https://hg.mozilla.org/l10n-central/en-GB/file/0f3c06bd68fc99da1a2e724f5a78119f922a64cc/toolkit/chrome/passwordmgr/passwordmgr.properties at line 23
+//% "Would you like to add a username to the saved password?"
+const auto update_login_msg_add_username = qtTrId("sailfish_components_webview_popups-la-update_login_msg_add_username");
+
+//: This is a transformed translation key, the original translation key
+//: (updateLoginMsg2) is from https://hg.mozilla.org/l10n-central/en-GB/file/0f3c06bd68fc99da1a2e724f5a78119f922a64cc/toolkit/chrome/passwordmgr/passwordmgr.properties at line 24
+//% "Update this login?"
+const auto update_login_msg2 = qtTrId("sailfish_components_webview_popups-la-update_login_msg2");
+
+//: This is a transformed translation key, the original translation key
+//: (updateLoginMsgNoUser2) is from https://hg.mozilla.org/l10n-central/en-GB/file/0f3c06bd68fc99da1a2e724f5a78119f922a64cc/toolkit/chrome/passwordmgr/passwordmgr.properties at line 25
+//% "Update this password?"
+const auto update_login_msg_no_user2 = qtTrId("sailfish_components_webview_popups-la-update_login_msg_no_user2");
+
+//: This is a transformed translation key, the original translation key
+//: (updateLoginMsg3) is from https://hg.mozilla.org/l10n-central/en-GB/file/0f3c06bd68fc99da1a2e724f5a78119f922a64cc/toolkit/chrome/passwordmgr/passwordmgr.properties at line 28
+//% "Update login for %1?"
+const auto update_login_msg3 = qtTrId("sailfish_components_webview_popups-la-update_login_msg3");
+
+//: This is a transformed translation key, the original translation key
+//: (updateLoginMsgNoUser3) is from https://hg.mozilla.org/l10n-central/en-GB/file/0f3c06bd68fc99da1a2e724f5a78119f922a64cc/toolkit/chrome/passwordmgr/passwordmgr.properties at line 29
+//% "Update password for %1?"
+const auto update_login_msg_no_user3 = qtTrId("sailfish_components_webview_popups-la-update_login_msg_no_user3");
+
+//: This is a transformed translation key, the original translation key
+//: (updateLoginMsgAddUsername2) is from https://hg.mozilla.org/l10n-central/en-GB/file/0f3c06bd68fc99da1a2e724f5a78119f922a64cc/toolkit/chrome/passwordmgr/passwordmgr.properties at line 30
+//% "Add username to saved password?"
+const auto update_login_msg_add_username2 = qtTrId("sailfish_components_webview_popups-la-update_login_msg_add_username2");
+
+//: This is a transformed translation key, the original translation key
+//: (updateLoginButtonText) is from https://hg.mozilla.org/l10n-central/en-GB/file/0f3c06bd68fc99da1a2e724f5a78119f922a64cc/toolkit/chrome/passwordmgr/passwordmgr.properties at line 31
+//% "Update"
+const auto update_login_button_text = qtTrId("sailfish_components_webview_popups-la-update_login_button_text");
+
+//: This is a transformed translation key, the original translation key
+//: (updateLoginButtonAccessKey) is from https://hg.mozilla.org/l10n-central/en-GB/file/0f3c06bd68fc99da1a2e724f5a78119f922a64cc/toolkit/chrome/passwordmgr/passwordmgr.properties at line 32
+//% "U"
+const auto update_login_button_access_key = qtTrId("sailfish_components_webview_popups-la-update_login_button_access_key");
+
+//: This is a transformed translation key, the original translation key
+//: (rememberPasswordMsg) is from https://hg.mozilla.org/l10n-central/en-GB/file/0f3c06bd68fc99da1a2e724f5a78119f922a64cc/toolkit/chrome/passwordmgr/passwordmgr.properties at line 40
+//% "Would you like to remember the password for “%1” on %2?"
+const auto remember_password_msg = qtTrId("sailfish_components_webview_popups-la-remember_password_msg");
+
+//: This is a transformed translation key, the original translation key
+//: (rememberPasswordMsgNoUsername) is from https://hg.mozilla.org/l10n-central/en-GB/file/0f3c06bd68fc99da1a2e724f5a78119f922a64cc/toolkit/chrome/passwordmgr/passwordmgr.properties at line 43
+//% "Would you like to remember the password on %1?"
+const auto remember_password_msg_no_username = qtTrId("sailfish_components_webview_popups-la-remember_password_msg_no_username");
+
+//: This is a transformed translation key, the original translation key
+//: (noUsernamePlaceholder) is from https://hg.mozilla.org/l10n-central/en-GB/file/0f3c06bd68fc99da1a2e724f5a78119f922a64cc/toolkit/chrome/passwordmgr/passwordmgr.properties at line 46
+//% "No username"
+const auto no_username_placeholder = qtTrId("sailfish_components_webview_popups-la-no_username_placeholder");
+
+//: This is a transformed translation key, the original translation key
+//: (togglePasswordLabel) is from https://hg.mozilla.org/l10n-central/en-GB/file/0f3c06bd68fc99da1a2e724f5a78119f922a64cc/toolkit/chrome/passwordmgr/passwordmgr.properties at line 47
+//% "Show password"
+const auto toggle_password_label = qtTrId("sailfish_components_webview_popups-la-toggle_password_label");
+
+//: This is a transformed translation key, the original translation key
+//: (togglePasswordAccessKey2) is from https://hg.mozilla.org/l10n-central/en-GB/file/0f3c06bd68fc99da1a2e724f5a78119f922a64cc/toolkit/chrome/passwordmgr/passwordmgr.properties at line 48
+//% "h"
+const auto toggle_password_access_key2 = qtTrId("sailfish_components_webview_popups-la-toggle_password_access_key2");
+
+//: This is a transformed translation key, the original translation key
+//: (notNowButtonText) is from https://hg.mozilla.org/l10n-central/en-GB/file/0f3c06bd68fc99da1a2e724f5a78119f922a64cc/toolkit/chrome/passwordmgr/passwordmgr.properties at line 49
+//% "Not Now"
+const auto not_now_button_text = qtTrId("sailfish_components_webview_popups-la-not_now_button_text");
+
+//: This is a transformed translation key, the original translation key
+//: (neverForSiteButtonText) is from https://hg.mozilla.org/l10n-central/en-GB/file/0f3c06bd68fc99da1a2e724f5a78119f922a64cc/toolkit/chrome/passwordmgr/passwordmgr.properties at line 50
+//% "Never for This Site"
+const auto never_for_site_button_text = qtTrId("sailfish_components_webview_popups-la-never_for_site_button_text");
+
+//: This is a transformed translation key, the original translation key
+//: (rememberButtonText) is from https://hg.mozilla.org/l10n-central/en-GB/file/0f3c06bd68fc99da1a2e724f5a78119f922a64cc/toolkit/chrome/passwordmgr/passwordmgr.properties at line 51
+//% "Remember"
+const auto remember_button_text = qtTrId("sailfish_components_webview_popups-la-remember_button_text");
+
+//: This is a transformed translation key, the original translation key
+//: (passwordChangeTitle) is from https://hg.mozilla.org/l10n-central/en-GB/file/0f3c06bd68fc99da1a2e724f5a78119f922a64cc/toolkit/chrome/passwordmgr/passwordmgr.properties at line 52
+//% "Confirm Password Change"
+const auto password_change_title = qtTrId("sailfish_components_webview_popups-la-password_change_title");
+
+//: This is a transformed translation key, the original translation key
+//: (updatePasswordMsg) is from https://hg.mozilla.org/l10n-central/en-GB/file/0f3c06bd68fc99da1a2e724f5a78119f922a64cc/toolkit/chrome/passwordmgr/passwordmgr.properties at line 55
+//% "Would you like to update the saved password for “%1”?"
+const auto update_password_msg = qtTrId("sailfish_components_webview_popups-la-update_password_msg");
+
+//: This is a transformed translation key, the original translation key
+//: (updatePasswordMsgNoUser) is from https://hg.mozilla.org/l10n-central/en-GB/file/0f3c06bd68fc99da1a2e724f5a78119f922a64cc/toolkit/chrome/passwordmgr/passwordmgr.properties at line 56
+//% "Would you like to update the saved password?"
+const auto update_password_msg_no_user = qtTrId("sailfish_components_webview_popups-la-update_password_msg_no_user");
+
+//: This is a transformed translation key, the original translation key
+//: (userSelectText2) is from https://hg.mozilla.org/l10n-central/en-GB/file/0f3c06bd68fc99da1a2e724f5a78119f922a64cc/toolkit/chrome/passwordmgr/passwordmgr.properties at line 57
+//% "Select which login to update:"
+const auto user_select_text2 = qtTrId("sailfish_components_webview_popups-la-user_select_text2");
+
+//: This is a transformed translation key, the original translation key
+//: (loginsDescriptionAll2) is from https://hg.mozilla.org/l10n-central/en-GB/file/0f3c06bd68fc99da1a2e724f5a78119f922a64cc/toolkit/chrome/passwordmgr/passwordmgr.properties at line 58
+//% "Logins for the following sites are stored on your computer"
+const auto logins_description_all2 = qtTrId("sailfish_components_webview_popups-la-logins_description_all2");
+
+//: This is a transformed translation key, the original translation key
+//: (useASecurelyGeneratedPassword) is from https://hg.mozilla.org/l10n-central/en-GB/file/0f3c06bd68fc99da1a2e724f5a78119f922a64cc/toolkit/chrome/passwordmgr/passwordmgr.properties at line 62
+//% "Use a Securely Generated Password"
+const auto use_asecurely_generated_password = qtTrId("sailfish_components_webview_popups-la-use_asecurely_generated_password");
+
+//: This is a transformed translation key, the original translation key
+//: (generatedPasswordWillBeSaved) is from https://hg.mozilla.org/l10n-central/en-GB/file/0f3c06bd68fc99da1a2e724f5a78119f922a64cc/toolkit/chrome/passwordmgr/passwordmgr.properties at line 65
+//% "%1 will save this password for this web site."
+const auto generated_password_will_be_saved = qtTrId("sailfish_components_webview_popups-la-generated_password_will_be_saved");
+
+//: This is a transformed translation key, the original translation key
+//: (loginHostAge) is from https://hg.mozilla.org/l10n-central/en-GB/file/0f3c06bd68fc99da1a2e724f5a78119f922a64cc/toolkit/chrome/passwordmgr/passwordmgr.properties at line 69
+//% "%1 (%2)"
+const auto login_host_age = qtTrId("sailfish_components_webview_popups-la-login_host_age");
+
+//: This is a transformed translation key, the original translation key
+//: (noUsername) is from https://hg.mozilla.org/l10n-central/en-GB/file/0f3c06bd68fc99da1a2e724f5a78119f922a64cc/toolkit/chrome/passwordmgr/passwordmgr.properties at line 72
+//% "No username"
+const auto no_username = qtTrId("sailfish_components_webview_popups-la-no_username");
+
+//: This is a transformed translation key, the original translation key
+//: (displaySameOrigin) is from https://hg.mozilla.org/l10n-central/en-GB/file/0f3c06bd68fc99da1a2e724f5a78119f922a64cc/toolkit/chrome/passwordmgr/passwordmgr.properties at line 75
+//% "From this web site"
+const auto display_same_origin = qtTrId("sailfish_components_webview_popups-la-display_same_origin");
+
+//: This is a transformed translation key, the original translation key
+//: (insecureFieldWarningDescription2) is from https://hg.mozilla.org/l10n-central/en-GB/file/0f3c06bd68fc99da1a2e724f5a78119f922a64cc/toolkit/chrome/passwordmgr/passwordmgr.properties at line 79
+//% "This connection is not secure. Logins entered here could be compromised. %1"
+const auto insecure_field_warning_description2 = qtTrId("sailfish_components_webview_popups-la-insecure_field_warning_description2");
+
+//: This is a transformed translation key, the original translation key
+//: (insecureFieldWarningLearnMore) is from https://hg.mozilla.org/l10n-central/en-GB/file/0f3c06bd68fc99da1a2e724f5a78119f922a64cc/toolkit/chrome/passwordmgr/passwordmgr.properties at line 80
+//% "Learn More"
+const auto insecure_field_warning_learn_more = qtTrId("sailfish_components_webview_popups-la-insecure_field_warning_learn_more");
+/* End of translations */

--- a/import/popups/popups.pro
+++ b/import/popups/popups.pro
@@ -19,7 +19,7 @@ OTHER_FILES += qmldir *.qml
 
 include(popupstranslations.pri)
 
-import.files = qmldir *.qml
+import.files = qmldir *.qml *.js
 import.path = $$TARGETPATH
 target.path = $$TARGETPATH
 

--- a/import/popups/popupstranslations.pri
+++ b/import/popups/popupstranslations.pri
@@ -1,8 +1,8 @@
 TS_FILE = $$OUT_PWD/sailfish_components_webview_popups_qt5.ts
 EE_QM = $$OUT_PWD/sailfish_components_webview_popups_qt5_eng_en.qm
 
-translations.commands += lupdate $$PWD -ts $$TS_FILE
-translations.depends = $$PWD/*.qml
+translations.commands += lupdate $$PWD $$PWD/generated -ts $$TS_FILE
+translations.depends = $$PWD/*.qml $$PWD/generated/*.cpp
 translations.CONFIG += no_check_exist no_link
 translations.output = $$TS_FILE
 translations.input = .
@@ -25,3 +25,5 @@ engineering_english_install.CONFIG += no_check_exist
 QMAKE_EXTRA_TARGETS += translations engineering_english
 
 PRE_TARGETDEPS += translations engineering_english
+
+OTHER_FILES += generated/*.cpp

--- a/import/popups/qmldir
+++ b/import/popups/qmldir
@@ -12,6 +12,7 @@ PasswordManagerPopupInterface 1.0 PasswordManagerPopupInterface.qml
 PromptPopupInterface 1.0 PromptPopupInterface.qml
 BlockedTabPopupInterface 1.0 BlockedTabPopupInterface.qml
 ContextMenuInterface 1.0 ContextMenuInterface.qml
+SelectorPopupInterface 1.0 SelectorPopupInterface.qml
 UserPromptUi 1.0 UserPromptUi.qml
 UserPromptDialog 1.0 UserPromptDialog.qml
 AlertDialog 1.0 AlertDialog.qml
@@ -23,6 +24,7 @@ PasswordManagerDialog 1.0 PasswordManagerDialog.qml
 PromptDialog 1.0 PromptDialog.qml
 BlockedTabPopupDialog 1.0 BlockedTabPopupDialog.qml
 ContextMenu 1.0 ContextMenu.qml
+SelectorDialog 1.0 SelectorDialog.qml
 PopupOpener 1.0 PopupOpener.qml
 PromptLabel 1.0 PromptLabel.qml
 DownloadMenuItem 1.0 DownloadMenuItem.qml

--- a/rpm/sailfish-components-webview.spec
+++ b/rpm/sailfish-components-webview.spec
@@ -118,6 +118,7 @@ BuildRequires:  qt5-tools
 %{_libdir}/qt5/qml/Sailfish/WebView/Popups/libsailfishwebviewpopupsplugin.so
 %{_libdir}/qt5/qml/Sailfish/WebView/Popups/qmldir
 %{_libdir}/qt5/qml/Sailfish/WebView/Popups/*.qml
+%{_libdir}/qt5/qml/Sailfish/WebView/Popups/*.js
 
 %files pickers
 %defattr(-,root,root,-)

--- a/sailfish-components-webview.pro
+++ b/sailfish-components-webview.pro
@@ -1,5 +1,5 @@
 TEMPLATE=subdirs
-SUBDIRS+=lib import tests examples doc
+SUBDIRS+=lib import tests examples doc tools
 OTHER_FILES += $$PWD/rpm/sailfish-components-webview.spec
 
 import.depends = lib

--- a/tools/generate_property_translations.py
+++ b/tools/generate_property_translations.py
@@ -9,7 +9,7 @@ DEFAULT_PREFIX = "sailfish_components_webview_popups-la"
 
 class Generator:
     TRANSLATION = re.compile(r"(?P<name>[\w-]+)\s*=\s*(?P<text>.*)\s*")
-    SPLITTER = re.compile(r"([A-Za-z0-9][a-z0-9]*)")
+    SPLITTER = re.compile(r"([a-z\d]+)([A-Z])")
     PLACEHOLDER = re.compile(r"%(?:([0-9]+)\$)?S")
 
     def __init__(self, file, source):
@@ -19,7 +19,7 @@ class Generator:
     @staticmethod
     def _convert_key(name):
         """Convert from camelCase to snake_case"""
-        return "_".join(Generator.SPLITTER.findall(name)).lower()
+        return re.sub(Generator.SPLITTER, r'\1_\2', name).lower()
 
     @staticmethod
     def _convert_text(text):

--- a/tools/tools.pro
+++ b/tools/tools.pro
@@ -1,0 +1,4 @@
+TEMPLATE = aux
+
+OTHER_FILES += \
+    $$PWD/*.py


### PR DESCRIPTION
Updates the default dialogs to use translation keys passed from the gecko engine for localisation of messages presented to the user.

Updates the documentation with info about the translation keys for custom dialog creation.

Adds a customisable Select custom dialog type for selecting multiple values in a dialog with a message.