### PR TITLE
[sailfish-components-webview] Prefill prompt input field with default value. Contributes to JB#52387 OMP#JOLLA-257

### DIFF
--- a/examples/custompopups/CustomPromptPopup.qml
+++ b/examples/custompopups/CustomPromptPopup.qml
@@ -21,8 +21,7 @@ PromptPopupInterface {
     cancelText: "Cancel"
 
     preventDialogsValue: toggle.checked
-
-    onAccepted: value = input.text
+    value: input.text
 
     Rectangle {
         anchors.fill: parent
@@ -52,6 +51,7 @@ PromptPopupInterface {
                     width: parent.width
                     focus: true
                     label: text.length > 0 ? popup.text : ""
+                    text: popup.defaultValue
                     placeholderText: popup.text
                     inputMethodHints: Qt.ImhNoPredictiveText | Qt.ImhNoAutoUppercase
                     EnterKey.enabled: text.length > 0

--- a/import/popups/PopupOpener.qml
+++ b/import/popups/PopupOpener.qml
@@ -173,11 +173,17 @@ Timer {
 
     // Open prompt dialog
     function prompt(data) {
+        var defaultValue = !!data.defaultValue
+                         ? data.defaultValue
+                         : (!!data.inputs[0].value
+                            ? data.inputs[0].value
+                            : "")
+
         var checkbox = getCheckbox(data)
         var winId = data.winId
         var props = {
             "text": data.text,
-            "value": data.defaultValue,
+            "defaultValue": defaultValue,
             "preventDialogsVisible": !(checkbox == null),
             "preventDialogsPrefillValue": (!(checkbox == null) ? checkbox.value : false)
         }

--- a/import/popups/PromptDialog.qml
+++ b/import/popups/PromptDialog.qml
@@ -18,7 +18,8 @@ Dialog {
     canAccept: input.text.length > 0
 
     property alias text: prompt.text
-    property alias value: input.text
+    property alias value: prompt.value
+    property alias defaultValue: prompt.defaultValue
 
     property alias acceptText: prompt.acceptText
     property alias cancelText: prompt.cancelText
@@ -51,6 +52,7 @@ Dialog {
                 width: parent.width
                 focus: true
                 label: text.length > 0 ? prompt.text : ""
+                text: prompt.defaultValue
                 placeholderText: prompt.text
                 inputMethodHints: Qt.ImhNoPredictiveText | Qt.ImhNoAutoUppercase
                 EnterKey.enabled: text.length > 0

--- a/import/popups/PromptPopupInterface.qml
+++ b/import/popups/PromptPopupInterface.qml
@@ -14,6 +14,7 @@ import Sailfish.Silica 1.0
 UserPromptInterface {
     // inputs
     property string text
+    property string defaultValue
 
     // outputs
     property string value


### PR DESCRIPTION
When passed a default value to be prefilled into the prompt input
field, we should set the input field's text value to that value.

In order to prevent two-way-binding problem, we need to pass this
default value as a separate input property, rather than attempting
to bind it to the (output) value property.