### PR TITLE
[sailfish-webview] Remove classes from top level index. Fixes JB#55581

### DIFF
--- a/doc/sailfish-webview.qdocconf
+++ b/doc/sailfish-webview.qdocconf
@@ -30,8 +30,8 @@ qhp.SailfishWebView.customFilters.SailfishWebView.filterAttributes = sailfishos-
 
 qhp.SailfishWebView.subprojects        = overview qmltypes classes
 
-qhp.SailfishWebView.subprojects.overview.title = Sailfish WebView
-qhp.SailfishWebView.subprojects.overview.indexTitle = Sailfish WebView
+qhp.SailfishWebView.subprojects.overview.title = Sailfish WebView Overview
+qhp.SailfishWebView.subprojects.overview.indexTitle = Sailfish WebView Overview
 qhp.SailfishWebView.subprojects.overview.type = manual
 qhp.SailfishWebView.subprojects.qmltypes.title = QML Types
 qhp.SailfishWebView.subprojects.qmltypes.indexTitle = Sailfish.WebView QML Types


### PR DESCRIPTION
The overlapping index title caused unwanted pages to appear in top
level index.