### PR TITLE
[sailfish-webview] Adjust text selection markers by scrollable offset. Fixes JB#55606 OMP#JOLLA-400

### DIFF
--- a/import/controls/TextSelectionController.qml
+++ b/import/controls/TextSelectionController.qml
@@ -49,8 +49,9 @@ MouseArea {
         var state = data.src
 
         // Start marker
-        start.fixedX = (data.start.xPos * resolution) - start.width
-        start.fixedY = data.start.yPos * resolution
+        start.fixedX = (data.start.xPos * resolution) - start.width - contentItem.scrollableOffset.x
+        start.fixedY = data.start.yPos * resolution - contentItem.scrollableOffset.y
+
         if (!selectionVisible) {
             start.x = start.fixedX
             start.y = start.fixedY
@@ -59,8 +60,8 @@ MouseArea {
         }
 
         // End marker
-        end.fixedX = data.end.xPos * resolution
-        end.fixedY = data.end.yPos * resolution
+        end.fixedX = data.end.xPos * resolution - contentItem.scrollableOffset.x
+        end.fixedY = data.end.yPos * resolution - contentItem.scrollableOffset.y
 
         if (!selectionVisible) {
             end.x = end.fixedX
@@ -139,12 +140,12 @@ MouseArea {
         return {
             change: markerTag,
             start: {
-                xPos: (start.x + start.width) / resolution,
-                yPos: start.y / resolution
+                xPos: (start.x + contentItem.scrollableOffset.x + start.width) / resolution,
+                yPos: (start.y + contentItem.scrollableOffset.y) / resolution
             },
             end: {
-                xPos: end.x / resolution,
-                yPos: end.y / resolution
+                xPos: (end.x + contentItem.scrollableOffset.x) / resolution,
+                yPos: (end.y + contentItem.scrollableOffset.y) / resolution
             },
             caret: {
                 xPos: 0,


### PR DESCRIPTION
Not entirely sure what has changed in embedlite-components or gecko but
now coordinates that TextSelectionController receives from the
embedlite-components (Content:SelectionRange) need to adjusted by
scroll offset in addition to resolution (zoom).

Reason for this could be as simple as Util.translateToTopLevelWindow
(embedlite-components Util.js), returning offset differently. That would
imply that initial context menu position would be different as
well (_processPopupNode) and context menu request changing to selection start
(Browser:SelectionStart) would pass the same different coordinates back
to the embedlite-components.

Engine side highlight was ok already before only user interface side markers
(QML items) were at wrong position.