### PR TITLE
Act on private browsing when requesting permissions. JB#55925 OMP#JOLLA-445

### DIFF
--- a/doc/sailfish-webview-popups-locationpopupinterface.qdoc
+++ b/doc/sailfish-webview-popups-locationpopupinterface.qdoc
@@ -27,6 +27,19 @@
 */
 
 /*!
+  \qmlproperty bool LocationPopupInterface::privateBrowsing
+  \brief Will be true if the user is in private browsing mode
+
+  A custom implementation should use the value of this property to determine
+  how to change the look-and-feel of the popup, to ensure that the user is
+  reminded that the web view is currently in private browsing mode.
+
+  Also, if in private browsing mode, the custom implementation should not
+  ask the user if they would like the web view to store the permission,
+  and as such it should hide its "remember" toggle switch.
+*/
+
+/*!
   \qmlproperty string LocationPopupInterface::host
   \brief The name of the site which is asking for permission to access the
          user's location

--- a/import/popups/LocationDialog.qml
+++ b/import/popups/LocationDialog.qml
@@ -15,6 +15,7 @@ import Sailfish.Silica 1.0
 Dialog {
     id: dialog
 
+    property alias privateBrowsing: location.privateBrowsing
     property alias host: location.host
     property alias rememberValue: location.rememberValue
 
@@ -64,9 +65,22 @@ Dialog {
                 TextSwitch {
                     id: remember
 
+                    visible: !location.privateBrowsing
                     //: Remember decision for this site for later use
                     //% "Remember for this site"
                     text: qsTrId("sailfish_components_webview_popups-remember_for_site")
+                }
+
+                Label {
+                    x: Theme.horizontalPageMargin
+                    width: parent.width - Theme.horizontalPageMargin * 2
+                    visible: location.privateBrowsing
+                    wrapMode: Text.Wrap
+                    color: Theme.highlightColor
+
+                    //: Description label for user when private mode active (entered permissions are not saved)
+                    //% "When in private browsing mode permissions choices are not stored"
+                    text: qsTrId("sailfish_components_webview_popups-la-private_browsing_premission_description")
                 }
             }
         }

--- a/import/popups/LocationPopupInterface.qml
+++ b/import/popups/LocationPopupInterface.qml
@@ -13,6 +13,7 @@ import Sailfish.Silica 1.0
 
 UserPromptInterface {
     // inputs
+    property bool privateBrowsing // "Remember" should only be shown if !privateBrowsing
     property string host
 
     // outputs

--- a/import/popups/PopupOpener.qml
+++ b/import/popups/PopupOpener.qml
@@ -342,7 +342,8 @@ Timer {
     // Open permissions dialog
     function permissions(data) {
         var props = {
-            "host": data.host
+            "host": data.host,
+            "privateBrowsing": data.privateBrowsing || true
         }
         var acceptFn = function(popup) {
             _popupObject = null


### PR DESCRIPTION
A `privateBrowsing` flag is now passed with the "embed:permissions" message when the browser wants to request a permission of the user (a location permission specifically).

This change disables the option to store the permission when private browsing is enabled, to avoid leaking location data.