### PR TITLE
Ensure geo permissions can be saved in normal browsing. Fixes JB#56207 OMP#JOLLA-509

### DIFF
--- a/import/popups/PopupOpener.qml
+++ b/import/popups/PopupOpener.qml
@@ -343,7 +343,7 @@ Timer {
     function permissions(data) {
         var props = {
             "host": data.host,
-            "privateBrowsing": data.privateBrowsing || true
+            "privateBrowsing": data.privateBrowsing
         }
         var acceptFn = function(popup) {
             _popupObject = null


### PR DESCRIPTION
A (rather embarrassing; sorry!) logic error meant that the permission dialogue thought it was always in private browsing mode, preventing the user from saving their geolocation permission setting.

Since the `privateBrowsing` entry will always be included in the message data, there should be no need to guard it anyway.