### PR TITLE
[sailfish-components-webview] Only populate permissions model with known permissions. Contributes to JB#56450 OMP#JOLLA-550

### DIFF
--- a/import/controls/permissionmodel.cpp
+++ b/import/controls/permissionmodel.cpp
@@ -134,9 +134,20 @@ void PermissionModel::handleRecvObserve(const QString &message, const QVariant &
 
 void PermissionModel::setPermissionList(const QVariantList &data)
 {
+    static const QStringList knownPermissions {
+        QStringLiteral("geolocation"),
+        QStringLiteral("cookie"),
+        QStringLiteral("popup"),
+        QStringLiteral("camera"),
+        QStringLiteral("microphone"),
+    };
+
     QList<Permission> permissions;
     for (const auto &iter : data) {
         QVariantMap varMap = iter.toMap();
+        if (!knownPermissions.contains(varMap.value("type").toString()))
+            continue;
+
         permissions.append(Permission(varMap.value("uri").toString(),
                                       varMap.value("type").toString(),
                                       PermissionManager::intToCapability(varMap.value("capability").toInt()),


### PR DESCRIPTION
If a permission isn't one of the permissions we are aware of (and
have an icon for) don't include it in the permissions model which
exposes it to QML.

Contributes to JB#56450