### PR TITLE
Document overloaded setPreference C++ method

### DIFF
--- a/doc/sailfish-webview-webenginesettings.cpp
+++ b/doc/sailfish-webview-webenginesettings.cpp
@@ -220,12 +220,8 @@ void SailfishOS::WebEngineSettings::enableLowPrecisionBuffers(bool enabled);
 
     This is a low-level API to set engine preferences. Higher-level calls, such
     as those provided by \l WebEngineSettings,
-    \l {SailfishOS::WebEngineSettings}{WebEngineSettings},
     \l {SailfishOS::WebEngine}{WebEngine} and \l {SailfishOS::WebView}{WebView}
     should be used in preference whenever possible.
-
-    See the \l {https://developer.mozilla.org/en-US/docs/Mozilla/Preferences?retiredLocale=ar}{MDN docs}
-    for more info about the available preferences.
 */
 void SailfishOS::WebEngineSettings::setPreference(const QString &key, const QVariant &value);
 

--- a/doc/sailfish-webview-webenginesettings.cpp
+++ b/doc/sailfish-webview-webenginesettings.cpp
@@ -88,6 +88,23 @@ namespace SailfishOS {
 */
 
 /*!
+    \enum SailfishOS::WebEngineSettings::PreferenceType
+
+    This enum type specifies possible preference types that can used.
+
+    \value UnknownPref
+           Unknown preference type.
+           WebEngineSettings interprets value on best effort basis.
+    \value StringPref
+           Preference interpreted as string type, commonly used with float as well.
+    \value IntPref
+           Preference interpreted as int type.
+    \value BoolPref
+           Preference interpreted as bool type (true or false).
+
+*/
+
+/*!
     \property SailfishOS::WebEngineSettings::cookieBehavior
     \brief Sets the cookie behaviour.
 
@@ -211,5 +228,16 @@ void SailfishOS::WebEngineSettings::enableLowPrecisionBuffers(bool enabled);
     for more info about the available preferences.
 */
 void SailfishOS::WebEngineSettings::setPreference(const QString &key, const QVariant &value);
+
+/*!
+    \brief Directly set gecko engine preferences.
+
+    This function overloads setPreference().
+
+    Sets the \a key preference to \a value. The \a type is the type of the prererence value.
+
+    \sa setPreference
+*/
+void SailfishOS::WebEngineSettings::setPreference(const QString &key, const QVariant &value, PreferenceType preferenceType);
 
 } // namespace SailfishOS

--- a/doc/sailfish-webview-webenginesettings.h
+++ b/doc/sailfish-webview-webenginesettings.h
@@ -47,6 +47,15 @@ public:
     };
     Q_ENUM(CookieBehavior)
 
+    // See https://github.com/sailfishos-mirror/gecko-dev/blob/esr78/modules/libpref/nsIPrefBranch.idl
+    enum PreferenceType {
+        UnknownPref = 0,
+        StringPref = 32,
+        IntPref = 64,
+        BoolPref = 128
+    };
+    Q_ENUM(PreferenceType)
+
     bool isInitialized() const;
 
     bool autoLoadImages() const;
@@ -77,6 +86,7 @@ public:
 
     // Low-level API to set engine preferences.
     Q_INVOKABLE void setPreference(const QString &key, const QVariant &value);
+    Q_INVOKABLE void setPreference(const QString &key, const QVariant &value, PreferenceType preferenceType);
 
 Q_SIGNALS:
     void autoLoadImagesChanged();

--- a/doc/sailfish-webview-webenginesettings.qdoc
+++ b/doc/sailfish-webview-webenginesettings.qdoc
@@ -110,11 +110,11 @@
 
     The cookie behaviour can be one of:
 
-    \value QMozEngineSettings.AcceptAll
+    \value WebEngineSettings.AcceptAll
            Accept all cookies independent of their origin, the default
-    \value QMozEngineSettings.BlockThirdParty
+    \value WebEngineSettings.BlockThirdParty
            Accept cookies only if they are from the requested domain.
-    \value QMozEngineSettings.BlockAll
+    \value WebEngineSettings.BlockAll
            Do not accept any cookies.
 
     This corresponds to the "network.cookie.cookieBehavior" gecko preference.
@@ -171,13 +171,14 @@
 
     The \a type can be one of:
 
-    \value QMozEngineSettings.UnknownPref
-           Unknown preference type, the default
-    \value QMozEngineSettings.StringPref
+    \value WebEngineSettings.UnknownPref
+           Unknown preference type, the default.
+           WebEngineSettings interprets value on best effort basis
+    \value WebEngineSettings.StringPref
            Preference interpreted as string type, commonly used with float as well.
-    \value QMozEngineSettings.IntPref
+    \value WebEngineSettings.IntPref
            Preference interpreted as int type.
-    \value QMozEngineSettings.BoolPref
+    \value WebEngineSettings.BoolPref
            Preference interpreted as bool type (true or false).
 
     This is a low-level API to set engine preferences. Higher-level calls, such


### PR DESCRIPTION
From QML point of view we can have setPreference documented as one method with one optional argument.