### PR TITLE
Remove embedlite.azpc.json.* forced defaults. JB#56765 OMP#JOLLA-607

### DIFF
--- a/lib/webenginesettings.cpp
+++ b/lib/webenginesettings.cpp
@@ -88,11 +88,6 @@ void SailfishOS::WebEngineSettings::initialize()
     SailfishOS::WebEngineSettings *engineSettings = instance();
 
     // Standard settings.
-    engineSettings->setPreference(QStringLiteral("embedlite.azpc.handle.singletap"), QVariant::fromValue<bool>(false));
-    engineSettings->setPreference(QStringLiteral("embedlite.azpc.json.singletap"), QVariant::fromValue<bool>(true));
-    engineSettings->setPreference(QStringLiteral("embedlite.azpc.handle.longtap"), QVariant::fromValue<bool>(false));
-    engineSettings->setPreference(QStringLiteral("embedlite.azpc.json.longtap"), QVariant::fromValue<bool>(true));
-    engineSettings->setPreference(QStringLiteral("embedlite.azpc.json.viewport"), QVariant::fromValue<bool>(true));
     // TODO: Fix this so that it can be applied during runtime when QQuickItem based WebView is used with QQuickFlickable.
     // At the moment just disable it to avoid unnecessary events being fired. JB#39581
 #if 0


### PR DESCRIPTION
The default values for these settings have now been moved to embedding.js in gecko-dev.

embedlite.azpc.handle.singletap
embedlite.azpc.handle.longtap
embedlite.azpc.json.viewport
embedlite.azpc.json.singletap
embedlite.azpc.json.longtap

Other embedlite.azpc.* settings can also be found there.