### PR TITLE
Disable wasm_baselinejit on lower memory devices. JB#56635 OMP#JOLLA-572

### DIFF
--- a/lib/lib.pro
+++ b/lib/lib.pro
@@ -12,10 +12,12 @@ PKGCONFIG += qt5embedwidget sailfishsilica
 INCLUDEPATH += $$system(pkg-config --cflags sailfishsilica)
 
 SOURCES += downloadhelper.cpp \
+           logging.cpp \
            webengine.cpp \
            webenginesettings.cpp
 
 HEADERS += downloadhelper.h \
+           logging.h \
            webengine.h \
            webengine_p.h \
            webenginesettings.h \
@@ -23,6 +25,7 @@ HEADERS += downloadhelper.h \
 
 develheaders.path = /usr/include/libsailfishwebengine
 develheaders.files = downloadhelper.h \
+                     logging.h \
                      webengine.h \
                      webenginesettings.h
 

--- a/lib/logging.cpp
+++ b/lib/logging.cpp
@@ -1,0 +1,15 @@
+/****************************************************************************
+**
+** Copyright (c) 2021 Open Mobile Platform LLC.
+**
+****************************************************************************/
+
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+#include "logging.h"
+
+Q_LOGGING_CATEGORY(lcWebviewLog, "org.sailfishos.webview", QtWarningMsg)
+Q_LOGGING_CATEGORY(lcWebengineLog, "org.sailfishos.webengine", QtWarningMsg)
+Q_LOGGING_CATEGORY(lcWebenginesettingsLog, "org.sailfishos.webenginesettings", QtWarningMsg)

--- a/lib/logging.h
+++ b/lib/logging.h
@@ -1,0 +1,20 @@
+/****************************************************************************
+**
+** Copyright (c) 2021 Open Mobile Platform LLC.
+**
+****************************************************************************/
+
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+#ifndef SAILFISHOS_LOGGING_H
+#define SAILFISHOS_LOGGING_H
+
+#include <QLoggingCategory>
+
+Q_DECLARE_LOGGING_CATEGORY(lcWebviewLog)
+Q_DECLARE_LOGGING_CATEGORY(lcWebengineLog)
+Q_DECLARE_LOGGING_CATEGORY(lcWebenginesettingsLog)
+
+#endif // SAILFISHOS_LOGGING_H

--- a/lib/webenginesettings.cpp
+++ b/lib/webenginesettings.cpp
@@ -22,6 +22,8 @@
 #include <QtGui/QStyleHints>
 #include <sys/sysinfo.h>
 
+#include "logging.h"
+
 Q_GLOBAL_STATIC(SailfishOS::WebEngineSettings, webEngineSettingsInstance)
 
 #define SAILFISH_WEBENGINE_DEFAULT_PIXEL_RATIO 1.5
@@ -113,7 +115,7 @@ void SailfishOS::WebEngineSettings::initialize()
     quint64 totalMemory = getTotalMemory();
     if (totalMemory < (2.5 * 1024 * 1024 * 1024)) {
         // Devices with roughly 2Gb and lower
-        qDebug() << "Lower memory: disabling wasm_baselinejit";
+        qCInfo(lcWebengineLog) << "Lower memory: disabling wasm_baselinejit";
         engineSettings->setPreference(QStringLiteral("javascript.options.wasm_baselinejit"), false);
     }
 


### PR DESCRIPTION
WebAssembly, and in particular the baselinejit, seems to have a heavy
memory footprint, which can cause the browser to crash on lower memory
devices (approx 2Gb or lower).

This change automatically disables wasm_baselinejit on devices with less
than 2.5Gb of RAM.