### PR TITLE
[components-webview] Respect component height. Fixes JB#57689

### DIFF
--- a/import/webview/WebView.qml
+++ b/import/webview/WebView.qml
@@ -66,7 +66,7 @@ RawWebView {
     _acceptTouchEvents: !textSelectionActive
 
     viewportHeight: webViewPage
-            ? ((webViewPage.orientation & Orientation.PortraitMask) ? Screen.height : Screen.width)
+            ? ((webViewPage.orientation & Orientation.PortraitMask) ? height : width)
             : undefined
 
     orientation: {


### PR DESCRIPTION
Ensures that the Gecko rendering height is the same as the component height, rather than being fixed to the height of the screen.

This prevents content being lost from the bottom of the WebView in case the height is shorter than the screen height.