### PR TITLE
[components-webview] Adjust keyboard margin based on position. JB#57689

### DIFF
--- a/import/webview/WebView.qml
+++ b/import/webview/WebView.qml
@@ -230,7 +230,7 @@ RawWebView {
         transpose: appWindow ? appWindow._transpose : false
         onImSizeChanged: {
             if (imSize > 0 && opened) {
-                webview.virtualKeyboardMargin = virtualKeyboardObserver.imSize
+                webview.virtualKeyboardMargin = marginRequired(virtualKeyboardObserver.imSize)
             }
         }
 
@@ -238,13 +238,18 @@ RawWebView {
 
         onOpenedChanged: {
             if (opened) {
-                webview.virtualKeyboardMargin = virtualKeyboardObserver.panelSize
+                webview.virtualKeyboardMargin = marginRequired(virtualKeyboardObserver.panelSize)
             }
         }
         onClosedChanged: {
             if (closed) {
                 webview.virtualKeyboardMargin = 0
             }
+        }
+
+        function marginRequired(panelSize) {
+            var ypos = appWindow ? appWindow.mapFromItem(null, 0, webview.y).y : 0
+            return margin = panelSize + ypos + webview.height - Screen.height
         }
     }
 


### PR DESCRIPTION
If the ypos and height of the WebView don't reach the base of the page, then the keyboard height must be compensated to adjust.

This is especially important in case a widget changes height when the keyboard opens, to avoid the margin being added twice.