### PR TITLE
[webview-docs] Add docs for doNotTrack and colorScheme. JB#58394

### DIFF
--- a/doc/sailfish-webview-webenginesettings.cpp
+++ b/doc/sailfish-webview-webenginesettings.cpp
@@ -105,8 +105,21 @@ namespace SailfishOS {
 */
 
 /*!
+    \enum SailfishOS::WebEngineSettings::ColorScheme
+
+    This enum type specifies the theme for the rendering engine to use.
+
+    \value PrefersLightMode
+           Use the light theme for the website if one is available.
+    \value PrefersDarkMode
+           Use the dark theme for the website if one is available.
+    \value FollowsAmbience
+           Select a theme (light or dark) depending on the current ambience.
+*/
+
+/*!
     \property SailfishOS::WebEngineSettings::cookieBehavior
-    \brief Sets the cookie behaviour.
+    \brief The cookie behaviour.
 
     The cookie behaviour can be one of:
 
@@ -124,7 +137,7 @@ namespace SailfishOS {
 
 /*!
     \property SailfishOS::WebEngineSettings::useDownloadDir
-    \brief Sets whether or not to use the default download location.
+    \brief Whether or not to use the default download location.
 
     When set to \c true downloaded files will be saved to the default download
     location, as specified by the \l downloadDir property. When set to \c false
@@ -137,7 +150,7 @@ namespace SailfishOS {
 
 /*!
     \property SailfishOS::WebEngineSettings::downloadDir
-    \brief Sets the location to save downloaded files to.
+    \brief The location to save downloaded files to.
 
     Specifies an absolute path location to save downloaded files to. This
     property applies only if the \l useDownloadDir property is set to \c true.
@@ -149,7 +162,7 @@ namespace SailfishOS {
 
 /*!
     \property SailfishOS::WebEngineSettings::pixelRatio
-    \brief Specifies the device to logical pixel ratio.
+    \brief The device to logical pixel ratio.
 
     This property represents the number of physical device pixels used to
     represent each logical pixel of the web rendering.
@@ -167,6 +180,36 @@ namespace SailfishOS {
 */
 
 /*!
+    \property SailfishOS::WebEngineSettings::doNotTrack
+    \brief Whether or not to send Do Not Track requests to websites
+
+    When set to \c true the browser will send "Do Not Track" requests
+    to websites using the DNT header field.
+
+    This corresponds to the "privacy.donottrackheader.enabled" gecko preference.
+*/
+
+/*!
+    \property SailfishOS::WebEngineSettings::colorScheme
+    \brief The theme to prefer when rendering websites.
+
+    Some websites provide sepearate "dark" and "light" themes. The
+    value of this property determines which of the variants the
+    browser will use to render the site:
+
+    The colour scheme can be one of:
+
+    \value WebEngineSettings.PrefersLightMode
+           Use the light theme for the website if one is available.
+    \value WebEngineSettings.PrefersDarkMode
+           Use the dark theme for the website if one is available.
+    \value WebEngineSettings.FollowsAmbience
+           Select a theme (light or dark) depending on the current ambience.
+
+    This corresponds to the "ui.systemUsesDarkTheme" gecko preference.
+*/
+
+/*!
     \brief Returns the instance of the singleton WebEngineSettings class.
 
     The returned instance may not be initialized.
@@ -180,7 +223,6 @@ namespace SailfishOS {
     {SailfishOS::WebEngineSettings::initialize}{WebEngineSettings::initialize}
 */
 WebEngineSettings *SailfishOS::WebEngineSettings::instance();
-
 
 /*!
     \brief Sets the tile \a size used for rendering pages.

--- a/doc/sailfish-webview-webenginesettings.h
+++ b/doc/sailfish-webview-webenginesettings.h
@@ -20,6 +20,7 @@ namespace SailfishOS {
 
 class WebEngineSettings : public QMozEngineSettings {
     Q_OBJECT
+    Q_PROPERTY(bool initialized READ isInitialized NOTIFY initialized)
     Q_PROPERTY(bool autoLoadImages READ autoLoadImages WRITE setAutoLoadImages NOTIFY autoLoadImagesChanged FINAL)
     Q_PROPERTY(bool javascriptEnabled READ javascriptEnabled WRITE setJavascriptEnabled NOTIFY javascriptEnabledChanged FINAL)
     Q_PROPERTY(bool popupEnabled READ popupEnabled WRITE setPopupEnabled NOTIFY popupEnabledChanged)
@@ -27,7 +28,8 @@ class WebEngineSettings : public QMozEngineSettings {
     Q_PROPERTY(bool useDownloadDir READ useDownloadDir WRITE setUseDownloadDir NOTIFY useDownloadDirChanged)
     Q_PROPERTY(QString downloadDir READ downloadDir WRITE setDownloadDir NOTIFY downloadDirChanged)
     Q_PROPERTY(qreal pixelRatio READ pixelRatio WRITE setPixelRatio NOTIFY pixelRatioChanged)
-    Q_PROPERTY(bool initialized READ isInitialized NOTIFY initialized)
+    Q_PROPERTY(bool doNotTrack READ doNotTrack WRITE setDoNotTrack NOTIFY doNotTrackChanged)
+    Q_PROPERTY(ColorScheme colorScheme READ colorScheme WRITE setColorScheme NOTIFY colorSchemeChanged)
 
 public:
     // C++ API
@@ -46,6 +48,13 @@ public:
         Deprecated = 3
     };
     Q_ENUM(CookieBehavior)
+
+    enum ColorScheme {
+        PrefersLightMode = 0,
+        PrefersDarkMode = 1,
+        FollowsAmbience = 2
+    };
+    Q_ENUM(ColorScheme)
 
     // See https://github.com/sailfishos-mirror/gecko-dev/blob/esr78/modules/libpref/nsIPrefBranch.idl
     enum PreferenceType {
@@ -80,6 +89,12 @@ public:
 
     void setPixelRatio(qreal pixelRatio);
     qreal pixelRatio() const;
+
+    bool doNotTrack() const;
+    void setDoNotTrack(bool doNotTrack);
+
+    ColorScheme colorScheme() const;
+    void setColorScheme(ColorScheme colorScheme);
 
     void enableProgressivePainting(bool enabled);
     void enableLowPrecisionBuffers(bool enabled);

--- a/doc/sailfish-webview-webenginesettings.qdoc
+++ b/doc/sailfish-webview-webenginesettings.qdoc
@@ -106,7 +106,7 @@
 
 /*!
     \qmlproperty enumeration WebEngineSettings::cookieBehavior
-    \brief Sets the cookie behaviour.
+    \brief The cookie behaviour.
 
     The cookie behaviour can be one of:
 
@@ -122,7 +122,7 @@
 
 /*!
     \qmlproperty bool WebEngineSettings::useDownloadDir
-    \brief Sets whether or not to use the default download location.
+    \brief Whether or not to use the default download location.
 
     When set to \c true downloaded files will be saved to the default download
     location, as specified by the \l downloadDir property. When set to \c false
@@ -135,7 +135,7 @@
 
 /*!
     \qmlproperty string WebEngineSettings::downloadDir
-    \brief Sets the location to save downloaded files to.
+    \brief The location to save downloaded files to.
 
     Specifies an absolute path location to save downloaded files to. This
     property applies only if the \l useDownloadDir property is set to \c true.
@@ -147,7 +147,7 @@
 
 /*!
     \qmlproperty real WebEngineSettings::pixelRatio
-    \brief Specifies the device to logical pixel ratio.
+    \brief The device to logical pixel ratio.
 
     This property represents the number of physical device pixels used to
     represent each logical pixel of the web rendering.
@@ -160,6 +160,36 @@
 
     \note Unlike desktop Firefox, changing this value will only change the
     rendering of web content; it does not affect the UI scaling.
+*/
+
+/*!
+    \qmlproperty bool WebEngineSettings::doNotTrack
+    \brief Whether or not to send Do Not Track requests to websites
+
+    When set to \c true the browser will send "Do Not Track" requests
+    to websites using the DNT header field.
+
+    This corresponds to the "privacy.donottrackheader.enabled" gecko preference.
+*/
+
+/*!
+    \qmlproperty bool WebEngineSettings::colorScheme
+    \brief The theme to prefer when rendering websites.
+
+    Some websites provide sepearate "dark" and "light" themes. The
+    value of this property determines which of the variants the
+    browser will use to render the site:
+
+    The colour scheme can be one of:
+
+    \value WebEngineSettings.PrefersLightMode
+           Use the light theme for the website if one is available.
+    \value WebEngineSettings.PrefersDarkMode
+           Use the dark theme for the website if one is available.
+    \value WebEngineSettings.FollowsAmbience
+           Select a theme (light or dark) depending on the current ambience.
+
+    This corresponds to the "ui.systemUsesDarkTheme" gecko preference.
 */
 
 /*!

--- a/lib/webenginesettings.h
+++ b/lib/webenginesettings.h
@@ -21,12 +21,16 @@ namespace SailfishOS {
 
 class WebEngineSettings : public QMozEngineSettings {
     Q_OBJECT
+
 public:
     static void initialize();
     static WebEngineSettings *instance();
 
     explicit WebEngineSettings(QObject *parent = 0);
     virtual ~WebEngineSettings();
+
+private slots:
+    void notifyColorSchemeChanged();
 };
 }
 


### PR DESCRIPTION
Sends an "ambience-theme-changed" notification with either "dark" or "light" data when the ambience changes, to be picked up by gecko.

Adds C++ and QML documentation to cover the WebEngineSettings::doNotTrack and WebEngineSettings::colorScheme properties.

Also amends the property brief text for other properties, to make them work better on the C++ page, where the brief text is automatically prefixed with the text "This property holds ".