### PR TITLE
[webview] Correctly update viewportHeight on orientation change. Fixes JB#59065

### DIFF
--- a/import/webview/WebView.qml
+++ b/import/webview/WebView.qml
@@ -65,9 +65,7 @@ RawWebView {
             || _appActive && (webViewPage.status === PageStatus.Deactivating)
     _acceptTouchEvents: !textSelectionActive
 
-    viewportHeight: webViewPage
-            ? ((webViewPage.orientation & Orientation.PortraitMask) ? height : width)
-            : undefined
+    viewportHeight: webViewPage ? height : undefined
 
     orientation: {
         switch (_pageOrientation) {


### PR DESCRIPTION
When the device orientation changes the WebView height must be updated to match. Previously this was based on the screen height and width, but didn't take into account the possibility of non-full-screen use. Commit df9ae3ced8e2a7c tried to fix this by switching screen height for widget height.

However the fix didn't consider the fact that the height and width are already reversed on orientation change. The result was that in portrait mode the wrong height was set.

This change attempts to address this by always using the widget height.