### PR TITLE
Changes needed for ESR 91

### DIFF
--- a/import/controls/TextSelectionController.qml
+++ b/import/controls/TextSelectionController.qml
@@ -11,7 +11,7 @@
 
 import QtQuick 2.1
 import Sailfish.Silica 1.0
-import QOfono 0.2
+import MeeGo.QOfono 0.2
 
 MouseArea {
     id: root

--- a/import/controls/TextSelectionController.qml
+++ b/import/controls/TextSelectionController.qml
@@ -11,7 +11,7 @@
 
 import QtQuick 2.1
 import Sailfish.Silica 1.0
-import MeeGo.QOfono 0.2
+import QOfono 0.2
 
 MouseArea {
     id: root

--- a/lib/webenginesettings.cpp
+++ b/lib/webenginesettings.cpp
@@ -110,6 +110,12 @@ void SailfishOS::WebEngineSettings::initialize()
     engineSettings->setPreference(QStringLiteral("intl.accept_languages"),
                                   QVariant::fromValue<QString>(langs));
 
+    // Ensure the renderer is configured correctly
+    engineSettings->setPreference(QStringLiteral("gfx.webrender.force-disabled"),
+                                  QVariant(true));
+    engineSettings->setPreference(QStringLiteral("embedlite.compositor.external_gl_context"),
+                                  QVariant(false));
+
     Silica::Theme *silicaTheme = Silica::Theme::instance();
 
     // Notify gecko when the ambience switches between light and dark
@@ -121,6 +127,8 @@ void SailfishOS::WebEngineSettings::initialize()
     }
     connect(silicaTheme, &Silica::Theme::colorSchemeChanged,
             engineSettings, &SailfishOS::WebEngineSettings::notifyColorSchemeChanged);
+
+    isInitialized = true;
 
     // Guard preferences that should be written only once. If a preference needs to be
     // forcefully written upon each start that should happen before this.
@@ -198,8 +206,6 @@ void SailfishOS::WebEngineSettings::initialize()
     // Enable user agent overrides
     engineSettings->setPreference(QStringLiteral("general.useragent.updates.enabled"),
                                   QVariant::fromValue<bool>(true));
-
-    isInitialized = true;
 
     markerFile.open(QIODevice::ReadWrite | QIODevice::Truncate);
     markerFile.close();

--- a/lib/webenginesettings.h
+++ b/lib/webenginesettings.h
@@ -20,6 +20,8 @@
 
 namespace SailfishOS {
 
+class WebEngineSettingsPrivate;
+
 class WebEngineSettings : public QMozEngineSettings
 {
     Q_OBJECT
@@ -31,8 +33,8 @@ public:
     explicit WebEngineSettings(QObject *parent = 0);
     virtual ~WebEngineSettings();
 
-private slots:
-    void notifyColorSchemeChanged();
+private:
+    WebEngineSettingsPrivate *d;
 };
 
 }

--- a/lib/webenginesettings_p.h
+++ b/lib/webenginesettings_p.h
@@ -1,0 +1,36 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+#ifndef SAILFISHOS_WEBENGINE_SETTINGS_P_H
+#define SAILFISHOS_WEBENGINE_SETTINGS_P_H
+
+#include <QObject>
+#include <QString>
+#include <webenginesettings.h>
+
+#ifndef Q_QDOC
+
+namespace SailfishOS {
+
+class WebEngineSettingsPrivate : public QObject
+{
+    Q_OBJECT
+
+public:
+    static WebEngineSettingsPrivate * instance();
+
+    explicit WebEngineSettingsPrivate(QObject *parent = 0);
+    ~WebEngineSettingsPrivate();
+
+public slots:
+    void notifyColorSchemeChanged();
+    void oneShotNotifyColorSchemeChanged(const QString &message, const QVariant &data);
+
+    friend class WebEngineSettings;
+};
+
+}
+
+#endif // !Q_QDOC
+#endif // SAILFISHOS_WEBENGINE_SETTINGS_P_H

--- a/rpm/sailfish-components-webview.spec
+++ b/rpm/sailfish-components-webview.spec
@@ -18,7 +18,7 @@ Requires: sailfishsilica-qt5 >= 1.1.123
 Requires: sailfish-components-media-qt5
 Requires: sailfish-components-pickers-qt5
 Requires: embedlite-components-qt5 >= 1.21.2
-Requires: libqofono-qt5-declarative >= 0.117
+Requires: libqofono-qt5-declarative >= 0.115
 
 %description
 %{summary}.

--- a/rpm/sailfish-components-webview.spec
+++ b/rpm/sailfish-components-webview.spec
@@ -1,6 +1,6 @@
 Name:    sailfish-components-webview-qt5
 Summary: Allows embedding Sailfish WebView into applications
-Version: 1.4.2
+Version: 1.5.21
 Release: 1
 License: MPLv2.0
 Url:     https://github.com/sailfishos/sailfish-components-webview

--- a/rpm/sailfish-components-webview.spec
+++ b/rpm/sailfish-components-webview.spec
@@ -18,7 +18,7 @@ Requires: sailfishsilica-qt5 >= 1.1.123
 Requires: sailfish-components-media-qt5
 Requires: sailfish-components-pickers-qt5
 Requires: embedlite-components-qt5 >= 1.21.2
-Requires: libqofono-qt5-declarative >= 0.115
+Requires: libqofono-qt5-declarative >= 0.117
 
 %description
 %{summary}.


### PR DESCRIPTION
These are the further changes I've needed to make to get the WebView working with the latest ESR 91 build. This adds two commits on top of  #168.

The first commit is to set the preferences as needed.

The second commit is to revert to the previous ofono import. I expect this second commit is only needed because of the SDK version I'm using (or maybe because I wasn't on devel?) and so almost certainly needs to be removed. I'm including it for completeness.

The first commit might be unnecessary as well?