### PR TITLE
Register types

### DIFF
--- a/import/controls/permissionmodel.cpp
+++ b/import/controls/permissionmodel.cpp
@@ -32,7 +32,6 @@ PermissionModel::PermissionModel(QObject *parent)
 
 void PermissionModel::classBegin()
 {
-
 }
 
 void PermissionModel::componentComplete()
@@ -144,6 +143,7 @@ void PermissionModel::setPermissionList(const QVariantList &data)
     };
 
     QList<Permission> permissions;
+
     for (const auto &iter : data) {
         QVariantMap varMap = iter.toMap();
         if (!knownPermissions.contains(varMap.value("type").toString()))
@@ -155,32 +155,31 @@ void PermissionModel::setPermissionList(const QVariantList &data)
                                       PermissionManager::intToExpiration(varMap.value("expireType").toInt())));
     }
 
-    int i = 0;
     int startIndex = -1;
-    for (i = 0; i < permissions.count() && i < m_permissionList.count(); i++) {
+    for (int i = 0; i < permissions.count() && i < m_permissionList.count(); i++) {
         if (m_permissionList.at(i) != permissions.at(i)) {
             m_permissionList[i] = permissions.at(i);
             if (startIndex < 0) {
                 startIndex = i;
             }
         } else if (startIndex >= 0) {
-            emit dataChanged(index(startIndex), index(i-1));
+            emit dataChanged(index(startIndex), index(i - 1));
             startIndex = -1;
         }
     }
 
     if (startIndex >= 0) {
-        emit dataChanged(index(startIndex), index(qMin(m_permissionList.count(), permissions.count())-1));
+        emit dataChanged(index(startIndex), index(qMin(m_permissionList.count(), permissions.count()) - 1));
     }
 
     int difference = permissions.count() - m_permissionList.count();
     if (difference != 0) {
         if (difference < 0) {
-            beginRemoveRows(QModelIndex(), permissions.count(), m_permissionList.count()-1);
-            m_permissionList.erase(m_permissionList.begin()+permissions.count(), m_permissionList.end());
+            beginRemoveRows(QModelIndex(), permissions.count(), m_permissionList.count() - 1);
+            m_permissionList.erase(m_permissionList.begin() + permissions.count(), m_permissionList.end());
             endRemoveRows();
         } else {
-            beginInsertRows(QModelIndex(), m_permissionList.count(), permissions.count()-1);
+            beginInsertRows(QModelIndex(), m_permissionList.count(), permissions.count() - 1);
             m_permissionList.append(permissions.mid(m_permissionList.count()));
             endInsertRows();
         }

--- a/import/controls/permissionmodel.h
+++ b/import/controls/permissionmodel.h
@@ -56,9 +56,9 @@ class PermissionModel : public QAbstractListModel, public QQmlParserStatus
 {
     Q_OBJECT
     Q_INTERFACES(QQmlParserStatus)
-
     Q_PROPERTY(QString host READ host WRITE setHost NOTIFY hostChanged)
     Q_PROPERTY(int count READ rowCount NOTIFY countChanged)
+
 public:
     enum Roles {
         Uri = Qt::UserRole,
@@ -70,19 +70,18 @@ public:
 
     PermissionModel(QObject *parent = nullptr);
 
-    /*
-     * If the user hasn't set host, then you should request for all possible permissions.
-     * It is better to do it after we have made sure that all bindings are initialized.
-    */
+    // If the user hasn't set host, then you should request for all possible permissions.
+    // It is better to do it after we have made sure that all bindings are initialized.
     void classBegin() override;
     void componentComplete() override;
 
-    /* Add host to exclusion list. The type property can be "geolocation", "cookie",
-     * "desktop-notification", "popup", etc. */
+    // Add host to exclusion list. The type property can be "geolocation", "cookie",
+    // "desktop-notification", "popup", etc.
     Q_INVOKABLE void add(const QString &host, const QString &type, int capability);
     Q_INVOKABLE void setCapability(QModelIndex index, int capability);
-    /* Remove all items from model for permission type.
-     * It can be "geolocation", "cookie", "popup", etc*/
+
+    // Remove all items from model for permission type.
+    // It can be "geolocation", "cookie", "popup", etc
     Q_INVOKABLE void removeAllForPermissionType(const QString &type);
 
     void remove(int index);
@@ -103,7 +102,6 @@ private slots:
     void setPermissionList(const QVariantList &data);
     void requestPermissions(const QString &host);
 
-private slots:
     void handleRecvObserve(const QString &message, const QVariant &data);
 
 private:

--- a/import/popups/PopupOpener.qml
+++ b/import/popups/PopupOpener.qml
@@ -121,6 +121,7 @@ Timer {
 
         _delayedOpenValues = null
         _popupObject = null
+
         switch (topic) {
         case "Content:ContextMenu": root._openContextMenu(data); break;
         case "embed:alert":         alert(data);    break;
@@ -295,6 +296,7 @@ Timer {
                 remember = inputs[i]
             }
         }
+
         var passwordOnly = !username
         var buttons = getButtonStringKeys(data, ["AcceptLogin", ""])
 
@@ -314,6 +316,7 @@ Timer {
             "passwordOnly": passwordOnly,
             "privateBrowsing": data.privateBrowsing || false
         }
+
         var acceptFn = function(popup) {
             _popupObject = null
             contentItem.sendAsyncMessage("authresponse", {

--- a/import/webview/plugin.cpp
+++ b/import/webview/plugin.cpp
@@ -26,6 +26,9 @@
 #include <QJsonObject>
 #include <QJsonValue>
 
+#include <qmozsecurity.h>
+#include <qmozscrolldecorator.h>
+
 namespace SailfishOS {
 
 namespace WebView {
@@ -37,6 +40,11 @@ void SailfishOSWebViewPlugin::registerTypes(const char *uri)
 {
     Q_ASSERT(uri == QLatin1String("Sailfish.WebView"));
     qmlRegisterType<SailfishOS::WebView::RawWebView>("Sailfish.WebView", 1, 0, "RawWebView");
+    // RawWebView inherits QuickMozView which has some pointer typed properties which need some extra
+    // registration. a bit hazy where these should be really registered but here it works,
+    // on QuickMozView ctor it doesn't
+    qmlRegisterType<QMozSecurity>();
+    qmlRegisterType<QMozScrollDecorator>();
 }
 
 void SailfishOSWebViewPlugin::initializeEngine(QQmlEngine *engine, const char *uri)


### PR DESCRIPTION
Main commit

    [components-webview] register some qtmozembed types to qml. JB#64103
    
    The QObject* based pointers need their types registered somewhere.
    Without these referring e.g. security.allGood was doing:
    
    LoadProperty:221 - QMetaProperty::read: Unable to handle
     unregistered datatype 'QMozSecurity*' for property
     'SignOnWebView_QMLTYPE_249::security
    
    Would be nice if this was done internal to qtmozembed but didn't
    quickly get that working.
