### PR TITLE
Adapt Sailfish WebView for ESR115

### DIFF
--- a/examples/custompopups/CustomAuthPopup.qml
+++ b/examples/custompopups/CustomAuthPopup.qml
@@ -84,7 +84,7 @@ AuthPopupInterface {
                 TextSwitch {
                     id: remember
 
-                    visible: !popup.privateBrowsing && !(popup.rememberVisible && popup.rememberPrefillValue)
+                    visible: popup.rememberVisible && !popup.privateBrowsing && !popup.rememberPrefillValue
                     checked: popup.rememberPrefillValue // bind the output value for when the prefill value is true.
                     text: "Remember these details?"
                 }

--- a/import/pickers/PickerOpener.qml
+++ b/import/pickers/PickerOpener.qml
@@ -16,7 +16,8 @@ import Sailfish.WebEngine 1.0
 QtObject {
     property var pageStack
     property QtObject contentItem
-    readonly property var listeners: [ "embed:filepicker",
+    readonly property var listeners: [ "embed:colorpicker",
+                                       "embed:filepicker",
                                        "embed:selectasync",
                                        "embedui:downloadpicker",
                                        "embed:downloadpicker" ]
@@ -24,6 +25,7 @@ QtObject {
     // Defer compilation of picker components
     readonly property string _multiSelectComponentUrl: Qt.resolvedUrl("MultiSelectDialog.qml")
     readonly property string _singleSelectComponentUrl: Qt.resolvedUrl("SingleSelectPage.qml")
+    readonly property string _colorPickerPageUrl: Qt.resolvedUrl("WebColorPickerPage.qml")
     readonly property string _filePickerComponentUrl: Qt.resolvedUrl("PickerCreator.qml")
     readonly property string _downloadPickerComponentUrl: Qt.resolvedUrl("DownloadPicker.qml")
     property Component _filePickerComponent
@@ -46,6 +48,14 @@ QtObject {
 
         var winId = data.winId
         switch (topic) {
+        case "embed:colorpicker": {
+            pageStack.animatorPush(_colorPickerPageUrl,
+                                   { "winId": winId,
+                                     "contentItem": contentItem,
+                                     "initialColor": data.initialColor,
+                                     "defaultColors": data.defaultColors })
+            break
+        }
         case "embed:selectasync": {
             pageStack.animatorPush(data.multiple ? _multiSelectComponentUrl : _singleSelectComponentUrl,
                                            { "options": data.options, "contentItem": contentItem })

--- a/import/pickers/WebColorPickerPage.qml
+++ b/import/pickers/WebColorPickerPage.qml
@@ -1,0 +1,79 @@
+/****************************************************************************
+**
+** Copyright (c) 2026 Jolla Mobile Ltd
+**
+****************************************************************************/
+
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import QtQuick 2.6
+import Sailfish.Silica 1.0
+
+ColorPickerPage {
+    id: colorPickerPage
+
+    property int winId
+    property QtObject contentItem
+    property string initialColor: "#000000"
+    property var defaultColors: []
+    property bool _completed
+
+    color: _cssColor(initialColor) || "#000000"
+
+    function _cssColor(value) {
+        var color = String(value).toLowerCase()
+        if (color.length === 9 && color.charAt(0) === "#") {
+            color = "#" + color.substring(3)
+        }
+        if (color.length !== 7 || color.charAt(0) !== "#") {
+            return ""
+        }
+
+        for (var i = 1; i < color.length; ++i) {
+            if ("0123456789abcdef".indexOf(color.charAt(i)) < 0) {
+                return ""
+            }
+        }
+        return color
+    }
+
+    function _sendResponse(accepted, selectedColor) {
+        if (contentItem) {
+            contentItem.sendAsyncMessage("embedui:colorpickerresponse",
+                                         {
+                                             "winId": winId,
+                                             "accepted": accepted,
+                                             "color": accepted ? selectedColor : ""
+                                         })
+        }
+    }
+
+    Component.onCompleted: {
+        if (defaultColors && defaultColors.length > 0) {
+            colors = defaultColors
+        }
+    }
+
+    Component.onDestruction: {
+        if (!_completed) {
+            _completed = true
+            _sendResponse(false, "")
+        }
+    }
+
+    onColorClicked: {
+        var selectedColor = _cssColor(color)
+        _completed = true
+        _sendResponse(selectedColor.length > 0, selectedColor)
+        pageStack.pop()
+    }
+
+    on_NavigationChanged: {
+        if (_navigation == PageNavigation.Back && !_completed) {
+            _completed = true
+            _sendResponse(false, "")
+        }
+    }
+}

--- a/import/pickers/qmldir
+++ b/import/pickers/qmldir
@@ -5,6 +5,7 @@ MultiSelectDialog 1.0 MultiSelectDialog.qml
 SingleSelectPage 1.0 SingleSelectPage.qml
 PickerCreator 1.0 PickerCreator.qml
 PickerOpener 1.0 PickerOpener.qml
+WebColorPickerPage 1.0 WebColorPickerPage.qml
 ContentPicker 1.0 ContentPicker.qml
 ImagePicker 1.0 ImagePicker.qml
 MultiContentPicker 1.0 MultiContentPicker.qml

--- a/import/popups/AuthDialog.qml
+++ b/import/popups/AuthDialog.qml
@@ -111,7 +111,7 @@ Dialog {
 
                     // If credentials are already remembered removing them via this is not feasible
                     // Better to hide the whole checkbox.
-                    visible: !auth.privateBrowsing && !(auth.rememberVisible && auth.rememberPrefillValue)
+                    visible: auth.rememberVisible && !auth.privateBrowsing && !auth.rememberPrefillValue
                     checked: auth.rememberPrefillValue // bind the output value for when the prefill value is true.
                     text: StringUtils.geckoKeyToString(auth.rememberMessageBundle)
                 }

--- a/import/popups/PopupOpener.qml
+++ b/import/popups/PopupOpener.qml
@@ -11,6 +11,7 @@
 
 import QtQuick 2.2
 import Sailfish.Silica 1.0
+import Sailfish.WebEngine 1.0
 import Sailfish.WebView.Popups 1.0 as Popups
 import Sailfish.WebView.Controls 1.0 as Controls
 
@@ -405,6 +406,18 @@ Timer {
     }
 
     function blocked(data) {
+        function respond(allow) {
+            if (data.popupId === undefined || data.winId === undefined) {
+                return
+            }
+
+            WebEngine.notifyObservers("embedui:popupblocked", {
+                "allow": allow,
+                "popupId": data.popupId,
+                "winId": data.winId
+            })
+        }
+
         openPopupByTopic("embed:popupblocked", null,
             // properties
             { "host": data.host },
@@ -417,6 +430,7 @@ Timer {
                         popup.rememberValue // rule expiry
                             ? Controls.PermissionManager.Never
                             : Controls.PermissionManager.Session)
+                respond(true)
             },
             // reject
             function(popup) {
@@ -427,6 +441,7 @@ Timer {
                             Controls.PermissionManager.Deny,
                             Controls.PermissionManager.Never) // expiry
                 }
+                respond(false)
             }
         )
     }

--- a/import/webview/TextZoom.js
+++ b/import/webview/TextZoom.js
@@ -1,0 +1,23 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+(function() {
+    "use strict";
+
+    function applyTextZoom(message) {
+        var data = message.data || message.json || {};
+        var zoom = Number(data.zoom);
+
+        if (!isFinite(zoom) || zoom <= 0) {
+            zoom = 1.0;
+        }
+
+        try {
+            docShell.browsingContext.textZoom = zoom;
+        } catch (e) {
+        }
+    }
+
+    addMessageListener("embedui:textZoom", applyTextZoom);
+})();

--- a/import/webview/TextZoomController.qml
+++ b/import/webview/TextZoomController.qml
@@ -1,0 +1,54 @@
+/****************************************************************************
+**
+** Copyright (c) 2026 Jolla Mobile Ltd
+**
+****************************************************************************/
+
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import QtQuick 2.6
+import Sailfish.Silica 1.0
+
+QtObject {
+    id: controller
+
+    property var webPage
+    property bool _frameScriptLoaded
+
+    readonly property real textZoom: Theme.fontSizeMedium / Theme.fontSizeMediumBase
+
+    property Connections webPageConnections: Connections {
+        target: controller.webPage
+        onDomContentLoadedChanged: {
+            if (controller.webPage.domContentLoaded) {
+                controller.updateTextZoom()
+            }
+        }
+    }
+
+    function updateTextZoom() {
+        if (!webPage) {
+            return
+        }
+
+        if (!_frameScriptLoaded) {
+            webPage.loadFrameScript(Qt.resolvedUrl("TextZoom.js"))
+            _frameScriptLoaded = true
+        }
+
+        if (webPage.domContentLoaded) {
+            webPage.sendAsyncMessage("embedui:textZoom", { "zoom": textZoom })
+        }
+    }
+
+    onWebPageChanged: {
+        _frameScriptLoaded = false
+        updateTextZoom()
+    }
+
+    onTextZoomChanged: updateTextZoom()
+
+    Component.onCompleted: updateTextZoom()
+}

--- a/import/webview/WebView.qml
+++ b/import/webview/WebView.qml
@@ -32,9 +32,27 @@ RawWebView {
     readonly property bool textSelectionActive: textSelectionController && textSelectionController.active
     property Item textSelectionController: null
     readonly property int _pageOrientation: webViewPage ? webViewPage.orientation : Orientation.None
+    property int _contentOrientation: orientation
     readonly property bool _appActive: Qt.application.state === Qt.ApplicationActive
+    readonly property int _topCutoutInset: Math.max(0, Screen.topCutout.y + Screen.topCutout.height)
 
     property alias popupProvider: popupOpener.popupProvider
+
+    function _cutoutSafeAreaTop(orientation) {
+        return orientation === Qt.PortraitOrientation ? _topCutoutInset : 0
+    }
+
+    function _cutoutSafeAreaRight(orientation) {
+        return orientation === Qt.InvertedLandscapeOrientation ? _topCutoutInset : 0
+    }
+
+    function _cutoutSafeAreaBottom(orientation) {
+        return orientation === Qt.InvertedPortraitOrientation ? _topCutoutInset : 0
+    }
+
+    function _cutoutSafeAreaLeft(orientation) {
+        return orientation === Qt.LandscapeOrientation ? _topCutoutInset : 0
+    }
 
     signal aboutToOpenPopup(var topic, var data)
     signal linkClicked(string url)
@@ -66,6 +84,10 @@ RawWebView {
     _acceptTouchEvents: !textSelectionActive
 
     viewportHeight: webViewPage ? height : undefined
+    safeAreaTop: _cutoutSafeAreaTop(_contentOrientation)
+    safeAreaRight: _cutoutSafeAreaRight(_contentOrientation)
+    safeAreaBottom: _cutoutSafeAreaBottom(_contentOrientation)
+    safeAreaLeft: _cutoutSafeAreaLeft(_contentOrientation)
 
     orientation: {
         switch (_pageOrientation) {
@@ -83,12 +105,14 @@ RawWebView {
     }
 
     onOrientationChanged: {
+        _contentOrientation = orientation
         if (visible) {
             orientationDelayOverlay.opacity = 1
         }
     }
 
     onContentOrientationChanged: {
+        _contentOrientation = orientation
         orientationFadeOut.restart()
     }
 

--- a/import/webview/WebView.qml
+++ b/import/webview/WebView.qml
@@ -37,6 +37,9 @@ RawWebView {
     readonly property int _topCutoutInset: Math.max(0, Screen.topCutout.y + Screen.topCutout.height)
 
     property alias popupProvider: popupOpener.popupProvider
+    property QtObject _textZoomController: TextZoomController {
+        webPage: webview
+    }
 
     function _cutoutSafeAreaTop(orientation) {
         return orientation === Qt.PortraitOrientation ? _topCutoutInset : 0

--- a/import/webview/plugin.cpp
+++ b/import/webview/plugin.cpp
@@ -14,10 +14,16 @@
 #include "webenginesettings.h"
 
 #include <QtCore/QStandardPaths>
+#include <QtCore/QCoreApplication>
+#include <QtCore/QEvent>
+#include <QtCore/QEventLoop>
+#include <QtCore/QPointer>
+#include <QtCore/QTimer>
 #include <QtQml/QQmlEngine>
 #include <QtQml/QQmlContext>
 
 #include <QQuickWindow>
+#include <QWindow>
 #include <QClipboard>
 #include <QGuiApplication>
 #include <QDir>
@@ -28,10 +34,243 @@
 
 #include <qmozsecurity.h>
 #include <qmozscrolldecorator.h>
+#include <qmozcontext.h>
 
 namespace SailfishOS {
 
 namespace WebView {
+
+namespace {
+
+class WebViewShutdownController : public QObject
+{
+public:
+    explicit WebViewShutdownController(SailfishOS::WebEngine *webEngine, QObject *parent)
+        : QObject(parent)
+        , m_webEngine(webEngine)
+    {
+        connect(webEngine, &SailfishOS::WebEngine::contextDestroyed, this, [this]() {
+            m_contextDestroyed = true;
+            if (m_shutdownWatchdog.isActive()) {
+                m_shutdownWatchdog.stop();
+            }
+            if (m_waitLoop) {
+                m_waitLoop->quit();
+            }
+            if (m_quitAfterShutdown) {
+                restoreQuitOnLastWindowClosed();
+                QCoreApplication::quit();
+            }
+        });
+        if (qGuiApp) {
+            connect(qGuiApp, &QGuiApplication::lastWindowClosed, this, [this]() {
+                scheduleShutdown(true);
+            });
+        }
+        connect(QCoreApplication::instance(), &QCoreApplication::aboutToQuit, this, [this]() {
+            shutdownAndWait();
+        });
+        m_shutdownWatchdog.setSingleShot(true);
+        connect(&m_shutdownWatchdog, &QTimer::timeout, this, [this]() {
+            qWarning() << "Timed out waiting for WebEngine shutdown";
+            restoreQuitOnLastWindowClosed();
+        });
+    }
+
+    void watchEngine(QQmlEngine *engine)
+    {
+        connect(engine, &QObject::destroyed, this, [this]() {
+            scheduleShutdown(false);
+        });
+    }
+
+    bool eventFilter(QObject *object, QEvent *event) override
+    {
+        if (event->type() == QEvent::Close) {
+            QWindow *window = qobject_cast<QWindow *>(object);
+            if (window && isLastVisibleWindow(window)) {
+                scheduleShutdown(true);
+            }
+        }
+
+        return QObject::eventFilter(object, event);
+    }
+
+private:
+    bool isLastVisibleWindow(QWindow *closingWindow) const
+    {
+        const QList<QWindow *> windows = QGuiApplication::topLevelWindows();
+        for (QWindow *window : windows) {
+            if (window != closingWindow && window->isVisible()) {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    void disableQuitOnLastWindowClosed()
+    {
+        if (!qGuiApp || m_savedQuitOnLastWindowClosed) {
+            return;
+        }
+
+        m_quitOnLastWindowClosed = qGuiApp->quitOnLastWindowClosed();
+        m_savedQuitOnLastWindowClosed = true;
+        if (m_quitOnLastWindowClosed) {
+            qGuiApp->setQuitOnLastWindowClosed(false);
+        }
+    }
+
+    void restoreQuitOnLastWindowClosed()
+    {
+        if (!qGuiApp || !m_savedQuitOnLastWindowClosed) {
+            return;
+        }
+
+        qGuiApp->setQuitOnLastWindowClosed(m_quitOnLastWindowClosed);
+        m_savedQuitOnLastWindowClosed = false;
+    }
+
+    void scheduleShutdown(bool quitAfterShutdown)
+    {
+        if (m_shutdownScheduled || m_shutdownStarted || m_shutdownInProgress
+                || m_contextDestroyed || !m_webEngine) {
+            return;
+        }
+
+        m_quitAfterShutdown = quitAfterShutdown;
+        if (quitAfterShutdown) {
+            disableQuitOnLastWindowClosed();
+        }
+
+        m_shutdownScheduled = true;
+        QTimer::singleShot(0, this, [this]() {
+            shutdown();
+        });
+    }
+
+    bool hasGeckoViews() const
+    {
+        return QMozContext::instance()->getNumberOfViews() != 0;
+    }
+
+    void destroyViewsAndWait()
+    {
+        if ((!RawWebView::hasLiveViews() && !hasGeckoViews()) || !m_webEngine) {
+            return;
+        }
+
+        QEventLoop waitLoop;
+        QTimer watchdog;
+        watchdog.setSingleShot(true);
+        connect(&watchdog, &QTimer::timeout, &waitLoop, &QEventLoop::quit);
+        connect(m_webEngine, &SailfishOS::WebEngine::lastViewDestroyed,
+                &waitLoop, &QEventLoop::quit);
+
+        RawWebView::destroyLiveViews();
+        QCoreApplication::sendPostedEvents(nullptr, QEvent::DeferredDelete);
+        QCoreApplication::processEvents(QEventLoop::ExcludeUserInputEvents);
+
+        if (RawWebView::hasLiveViews() || hasGeckoViews()) {
+            watchdog.start(2000);
+            waitLoop.exec(QEventLoop::ExcludeUserInputEvents);
+            QCoreApplication::sendPostedEvents(nullptr, QEvent::DeferredDelete);
+            QCoreApplication::processEvents(QEventLoop::ExcludeUserInputEvents);
+        }
+
+        if (RawWebView::hasLiveViews() || hasGeckoViews()) {
+            qWarning() << "Timed out waiting for WebView items to be destroyed";
+        }
+    }
+
+    void startShutdown()
+    {
+        if (m_shutdownStarted || m_contextDestroyed || !m_webEngine) {
+            return;
+        }
+
+        m_shutdownStarted = true;
+        m_webEngine->stopEmbedding();
+    }
+
+    void shutdown()
+    {
+        if (m_shutdownInProgress || m_contextDestroyed || !m_webEngine) {
+            return;
+        }
+
+        m_shutdownScheduled = false;
+        m_shutdownInProgress = true;
+        destroyViewsAndWait();
+        startShutdown();
+        if (!m_contextDestroyed) {
+            m_shutdownWatchdog.start(5000);
+        }
+        m_shutdownInProgress = false;
+    }
+
+    void waitForContextDestroyed()
+    {
+        if (m_contextDestroyed || !m_webEngine) {
+            return;
+        }
+
+        QEventLoop waitLoop;
+        QTimer watchdog;
+        watchdog.setSingleShot(true);
+        connect(&watchdog, &QTimer::timeout, &waitLoop, &QEventLoop::quit);
+        connect(m_webEngine, &SailfishOS::WebEngine::contextDestroyed,
+                &waitLoop, &QEventLoop::quit);
+
+        m_waitLoop = &waitLoop;
+        watchdog.start(5000);
+        waitLoop.exec(QEventLoop::ExcludeUserInputEvents);
+        m_waitLoop = nullptr;
+
+        if (!m_contextDestroyed) {
+            qWarning() << "Timed out waiting for WebEngine shutdown";
+        }
+    }
+
+    void shutdownAndWait()
+    {
+        if (m_shutdownInProgress || m_contextDestroyed || !m_webEngine) {
+            return;
+        }
+
+        m_shutdownInProgress = true;
+        destroyViewsAndWait();
+        startShutdown();
+        waitForContextDestroyed();
+        restoreQuitOnLastWindowClosed();
+        m_shutdownInProgress = false;
+    }
+
+private:
+    QPointer<SailfishOS::WebEngine> m_webEngine;
+    QTimer m_shutdownWatchdog;
+    QEventLoop *m_waitLoop = nullptr;
+    bool m_shutdownStarted = false;
+    bool m_shutdownInProgress = false;
+    bool m_shutdownScheduled = false;
+    bool m_quitAfterShutdown = false;
+    bool m_savedQuitOnLastWindowClosed = false;
+    bool m_quitOnLastWindowClosed = true;
+    bool m_contextDestroyed = false;
+};
+
+WebViewShutdownController *shutdownController(SailfishOS::WebEngine *webEngine)
+{
+    static QPointer<WebViewShutdownController> controller;
+    if (!controller) {
+        controller = new WebViewShutdownController(webEngine, QCoreApplication::instance());
+        QCoreApplication::instance()->installEventFilter(controller);
+    }
+    return controller;
+}
+
+}
 
 const auto MOZILLA_DATA_UA_UPDATE = QStringLiteral("ua-update.json");
 const auto MOZILLA_DATA_UA_UPDATE_SOURCE = QStringLiteral("/usr/share/sailfish-browser/data/ua-update.json.in");
@@ -72,8 +311,7 @@ void SailfishOSWebViewPlugin::initializeEngine(QQmlEngine *engine, const char *u
     // correctly.
     engineSettings->setPreference("layers.low-precision-buffer", QVariant::fromValue<bool>(false));
 
-    // TODO : Stop embedding after lastWindow is destroyed.
-    connect(engine, SIGNAL(destroyed()), webEngine, SLOT(stopEmbedding()));
+    shutdownController(webEngine)->watchEngine(engine);
 
     connect(webEngine, &SailfishOS::WebEngine::recvObserve, [](const QString &message, const QVariant &data) {
         const QVariantMap dataMap = data.toMap();
@@ -156,4 +394,3 @@ void SailfishOSWebViewPlugin::initUserAgentOverrides(const QString &path)
 } // namespace WebView
 
 } // namespace SailfishOS
-

--- a/import/webview/plugins.qmltypes
+++ b/import/webview/plugins.qmltypes
@@ -328,7 +328,12 @@ Module {
         exportMetaObjectRevisions: [0]
         Property { name: "virtualKeyboardMargin"; type: "float" }
         Property { name: "footerMargin"; type: "float" }
+        Property { name: "safeAreaTop"; type: "int" }
+        Property { name: "safeAreaRight"; type: "int" }
+        Property { name: "safeAreaBottom"; type: "int" }
+        Property { name: "safeAreaLeft"; type: "int" }
         Property { name: "_acceptTouchEvents"; type: "bool" }
+        Signal { name: "safeAreaChanged" }
         Signal {
             name: "contentOrientationChanged"
             Parameter { name: "orientation"; type: "Qt::ScreenOrientation" }

--- a/import/webview/qmldir
+++ b/import/webview/qmldir
@@ -4,3 +4,4 @@ typeinfo plugins.qmltypes
 WebView 1.0 WebView.qml
 WebViewFlickable 1.0 WebViewFlickable.qml
 WebViewPage 1.0 WebViewPage.qml
+TextZoomController 1.0 TextZoomController.qml

--- a/import/webview/rawwebview.cpp
+++ b/import/webview/rawwebview.cpp
@@ -41,9 +41,16 @@ public:
     quint32 createView(const quint32 &parentId, const uintptr_t &parentBrowsingContext, const bool hidden = false) override;
 
     static std::shared_ptr<ViewCreator> instance();
+    static std::shared_ptr<ViewCreator> existingInstance();
 
     std::vector<RawWebView *> views;
 };
+
+std::weak_ptr<ViewCreator> &viewCreatorInstance()
+{
+    static std::weak_ptr<ViewCreator> instance;
+    return instance;
+}
 
 ViewCreator::ViewCreator()
 {
@@ -72,15 +79,18 @@ quint32 ViewCreator::createView(const quint32 &parentId, const uintptr_t &parent
 
 std::shared_ptr<ViewCreator> ViewCreator::instance()
 {
-    static std::weak_ptr<ViewCreator> instance;
-
-    std::shared_ptr<ViewCreator> creator = instance.lock();
+    std::shared_ptr<ViewCreator> creator = viewCreatorInstance().lock();
     if (!creator) {
         creator = std::make_shared<ViewCreator>();
-        instance = creator;
+        viewCreatorInstance() = creator;
     }
 
     return creator;
+}
+
+std::shared_ptr<ViewCreator> ViewCreator::existingInstance()
+{
+    return viewCreatorInstance().lock();
 }
 
 
@@ -101,6 +111,27 @@ RawWebView::RawWebView(QQuickItem *parent)
 RawWebView::~RawWebView()
 {
     m_viewCreator->views.erase(std::find(m_viewCreator->views.begin(), m_viewCreator->views.end(), this));
+}
+
+bool RawWebView::hasLiveViews()
+{
+    std::shared_ptr<ViewCreator> creator = ViewCreator::existingInstance();
+    return creator && !creator->views.empty();
+}
+
+void RawWebView::destroyLiveViews()
+{
+    std::shared_ptr<ViewCreator> creator = ViewCreator::existingInstance();
+    if (!creator) {
+        return;
+    }
+
+    const std::vector<RawWebView *> views = creator->views;
+    for (RawWebView *view : views) {
+        if (view) {
+            view->deleteLater();
+        }
+    }
 }
 
 qreal RawWebView::virtualKeyboardMargin() const

--- a/import/webview/rawwebview.cpp
+++ b/import/webview/rawwebview.cpp
@@ -16,6 +16,7 @@
 
 #include <qmozviewcreator.h>
 
+#include <QtCore/QtGlobal>
 #include <QtGui/QGuiApplication>
 #include <QtGui/QScreen>
 #include <QtGui/QStyleHints>
@@ -135,6 +136,59 @@ void RawWebView::setFooterMargin(qreal margin)
     }
 }
 
+int RawWebView::safeAreaTop() const
+{
+    return m_safeAreaInsets.top();
+}
+
+void RawWebView::setSafeAreaTop(int top)
+{
+    applySafeAreaInsets(QMargins(m_safeAreaInsets.left(), qMax(0, top),
+                                 m_safeAreaInsets.right(), m_safeAreaInsets.bottom()));
+}
+
+int RawWebView::safeAreaRight() const
+{
+    return m_safeAreaInsets.right();
+}
+
+void RawWebView::setSafeAreaRight(int right)
+{
+    applySafeAreaInsets(QMargins(m_safeAreaInsets.left(), m_safeAreaInsets.top(),
+                                 qMax(0, right), m_safeAreaInsets.bottom()));
+}
+
+int RawWebView::safeAreaBottom() const
+{
+    return m_safeAreaInsets.bottom();
+}
+
+void RawWebView::setSafeAreaBottom(int bottom)
+{
+    applySafeAreaInsets(QMargins(m_safeAreaInsets.left(), m_safeAreaInsets.top(),
+                                 m_safeAreaInsets.right(), qMax(0, bottom)));
+}
+
+int RawWebView::safeAreaLeft() const
+{
+    return m_safeAreaInsets.left();
+}
+
+void RawWebView::setSafeAreaLeft(int left)
+{
+    applySafeAreaInsets(QMargins(qMax(0, left), m_safeAreaInsets.top(),
+                                 m_safeAreaInsets.right(), m_safeAreaInsets.bottom()));
+}
+
+void RawWebView::applySafeAreaInsets(const QMargins &insets)
+{
+    if (m_safeAreaInsets != insets) {
+        m_safeAreaInsets = insets;
+        setSafeAreaInsets(insets);
+        emit safeAreaChanged();
+    }
+}
+
 bool RawWebView::acceptTouchEvents() const
 {
     return m_acceptTouchEvents;
@@ -187,10 +241,27 @@ void RawWebView::touchEvent(QTouchEvent *event)
                         break;
                     }
 
-                    if ((delta.y() >= dragThreshold && !atYBeginning())
-                            || (delta.y() <= -dragThreshold && !atYEnd())
-                            || (delta.x() >= dragThreshold && !atXBeginning())
-                            || (delta.x() <= -dragThreshold && !atXEnd())) {
+                    const bool unavailableMetrics = scrollableSize().isEmpty();
+                    const qreal pageGestureMargin = qMax<qreal>(dragThreshold * 2,
+                                                                width() / 4.0);
+                    const qreal startX = mapFromScene(m_startPos).x();
+                    const bool pageGestureFromLeftEdge = startX <= pageGestureMargin;
+                    const bool pageGestureFromRightEdge = startX >= width() - pageGestureMargin;
+
+                    if ((delta.y() >= dragThreshold
+                                    && (!atYBeginning()
+                                        || (unavailableMetrics
+                                            && scrollableOffset().y() > 0.0)))
+                            || (delta.y() <= -dragThreshold
+                                    && (!atYEnd() || unavailableMetrics))
+                            || (delta.x() >= dragThreshold
+                                    && !pageGestureFromLeftEdge
+                                    && (!atXBeginning()
+                                        || (unavailableMetrics
+                                            && scrollableOffset().x() > 0.0)))
+                            || (delta.x() <= -dragThreshold
+                                    && !pageGestureFromRightEdge
+                                    && (!atXEnd() || unavailableMetrics))) {
                         setKeepMouseGrab(true);
                         setKeepTouchGrab(true);
                     }
@@ -236,4 +307,3 @@ void RawWebView::onAsyncMessage(const QString &message, const QVariant &data)
 } // namespace WebView
 
 } // namespace SailfishOS
-

--- a/import/webview/rawwebview.h
+++ b/import/webview/rawwebview.h
@@ -40,6 +40,9 @@ public:
     RawWebView(QQuickItem *parent = 0);
     ~RawWebView();
 
+    static bool hasLiveViews();
+    static void destroyLiveViews();
+
     qreal virtualKeyboardMargin() const;
     void setVirtualKeyboardMargin(qreal vkbMargin);
 

--- a/import/webview/rawwebview.h
+++ b/import/webview/rawwebview.h
@@ -12,6 +12,7 @@
 #ifndef SAILFISHOS_WEBVIEW_H
 #define SAILFISHOS_WEBVIEW_H
 
+#include <QtCore/QMargins>
 #include <QtQuick/QQuickItem>
 
 //mozembedlite-qt5
@@ -29,6 +30,10 @@ class RawWebView : public QuickMozView
     Q_OBJECT
     Q_PROPERTY(qreal virtualKeyboardMargin READ virtualKeyboardMargin WRITE setVirtualKeyboardMargin NOTIFY virtualKeyboardMarginChanged)
     Q_PROPERTY(qreal footerMargin READ footerMargin WRITE setFooterMargin NOTIFY footerMarginChanged)
+    Q_PROPERTY(int safeAreaTop READ safeAreaTop WRITE setSafeAreaTop NOTIFY safeAreaChanged)
+    Q_PROPERTY(int safeAreaRight READ safeAreaRight WRITE setSafeAreaRight NOTIFY safeAreaChanged)
+    Q_PROPERTY(int safeAreaBottom READ safeAreaBottom WRITE setSafeAreaBottom NOTIFY safeAreaChanged)
+    Q_PROPERTY(int safeAreaLeft READ safeAreaLeft WRITE setSafeAreaLeft NOTIFY safeAreaChanged)
     Q_PROPERTY(bool _acceptTouchEvents READ acceptTouchEvents WRITE setAcceptTouchEvents NOTIFY acceptTouchEventsChanged)
 
 public:
@@ -41,6 +46,18 @@ public:
     qreal footerMargin() const;
     void setFooterMargin(qreal margin);
 
+    int safeAreaTop() const;
+    void setSafeAreaTop(int top);
+
+    int safeAreaRight() const;
+    void setSafeAreaRight(int right);
+
+    int safeAreaBottom() const;
+    void setSafeAreaBottom(int bottom);
+
+    int safeAreaLeft() const;
+    void setSafeAreaLeft(int left);
+
     bool acceptTouchEvents() const;
     void setAcceptTouchEvents(bool accept);
 
@@ -50,16 +67,19 @@ protected:
 signals:
     void virtualKeyboardMarginChanged();
     void footerMarginChanged();
+    void safeAreaChanged();
     void contentOrientationChanged(Qt::ScreenOrientation orientation);
     void acceptTouchEventsChanged();
     void openUrlInNewWindow();
 
 private:
+    void applySafeAreaInsets(const QMargins &insets);
     void onAsyncMessage(const QString &message, const QVariant &data);
 
     std::shared_ptr<ViewCreator> m_viewCreator;
     qreal m_vkbMargin;
     qreal m_footerMargin;
+    QMargins m_safeAreaInsets;
     QPointF m_startPos;
     bool m_acceptTouchEvents;
 };

--- a/import/webview/webview.pro
+++ b/import/webview/webview.pro
@@ -21,11 +21,11 @@ HEADERS += plugin.h \
             rawwebview.h
 SOURCES += plugin.cpp \
             rawwebview.cpp
-OTHER_FILES += qmldir plugins.qmltypes *.qml
+OTHER_FILES += qmldir plugins.qmltypes *.qml *.js
 
 include(translations.pri)
 
-import.files = qmldir plugins.qmltypes *.qml
+import.files = qmldir plugins.qmltypes *.qml *.js
 import.path = $$TARGETPATH
 target.path = $$TARGETPATH
 

--- a/lib/webenginesettings.cpp
+++ b/lib/webenginesettings.cpp
@@ -128,12 +128,6 @@ void SailfishOS::WebEngineSettings::initialize()
     engineSettings->setPreference(QStringLiteral("intl.accept_languages"),
                                   QVariant::fromValue<QString>(langs));
 
-    // Ensure the renderer is configured correctly
-    engineSettings->setPreference(QStringLiteral("gfx.webrender.force-disabled"),
-                                  QVariant(true));
-    engineSettings->setPreference(QStringLiteral("embedlite.compositor.external_gl_context"),
-                                  QVariant(false));
-
     Silica::Theme *silicaTheme = Silica::Theme::instance();
 
     // Notify gecko when the ambience switches between light and dark
@@ -152,6 +146,24 @@ void SailfishOS::WebEngineSettings::initialize()
     connect(webEngine, &SailfishOS::WebEngine::recvObserve,
             engineSettings->d, &SailfishOS::WebEngineSettingsPrivate::oneShotNotifyColorSchemeChanged);
     webEngine->addObserver(QStringLiteral("embedliteviewcreated"));
+
+    qreal pixelRatio = SAILFISH_WEBENGINE_DEFAULT_PIXEL_RATIO * silicaTheme->pixelRatio();
+    // Round to nearest even rounding factor
+    pixelRatio = qRound(pixelRatio / 0.5) * 0.5;
+
+    int screenWidth = QGuiApplication::primaryScreen()->size().width();
+
+    // Do not floor the pixel ratio if the pixel ratio less than 2.0 (1.5 is minimum).
+    if (pixelRatio >= 2.0 && !testScreenDimensions(pixelRatio)) {
+        qreal tempPixelRatio = qFloor(pixelRatio);
+        if (testScreenDimensions(tempPixelRatio)) {
+            pixelRatio = tempPixelRatio;
+        }
+    } else if (screenWidth >= 1080) {
+        pixelRatio = qRound(pixelRatio);
+    }
+
+    engineSettings->setPixelRatio(pixelRatio);
 
     isInitialized = true;
 
@@ -191,24 +203,6 @@ void SailfishOS::WebEngineSettings::initialize()
     const int dragThreshold = QGuiApplication::styleHints()->startDragDistance();
     qreal touchStartTolerance = dragThreshold / QGuiApplication::primaryScreen()->physicalDotsPerInch();
     engineSettings->setPreference(QString("apz.touch_start_tolerance"), QString("%1").arg(touchStartTolerance));
-
-    qreal pixelRatio = SAILFISH_WEBENGINE_DEFAULT_PIXEL_RATIO * silicaTheme->pixelRatio();
-    // Round to nearest even rounding factor
-    pixelRatio = qRound(pixelRatio / 0.5) * 0.5;
-
-    int screenWidth = QGuiApplication::primaryScreen()->size().width();
-
-    // Do not floor the pixel ratio if the pixel ratio less than 2.0 (1.5 is minimum).
-    if (pixelRatio >= 2.0 && !testScreenDimensions(pixelRatio)) {
-        qreal tempPixelRatio = qFloor(pixelRatio);
-        if (testScreenDimensions(tempPixelRatio)) {
-            pixelRatio = tempPixelRatio;
-        }
-    } else if (screenWidth >= 1080) {
-        pixelRatio = qRound(pixelRatio);
-    }
-
-    engineSettings->setPixelRatio(pixelRatio);
 
     int tileSize = screenWidth;
 

--- a/rpm/sailfish-components-webview.spec
+++ b/rpm/sailfish-components-webview.spec
@@ -1,6 +1,6 @@
 Name:    sailfish-components-webview-qt5
 Summary: Allows embedding Sailfish WebView into applications
-Version: 1.6.0
+Version: 1.7.0
 Release: 1
 License: MPLv2.0
 Url:     https://github.com/sailfishos/sailfish-components-webview
@@ -17,7 +17,7 @@ BuildRequires:  qt5-qttools-linguist
 Requires: sailfishsilica-qt5 >= 1.1.123
 Requires: sailfish-components-media-qt5
 Requires: sailfish-components-pickers-qt5
-Requires: embedlite-components-qt5 >= 1.21.2
+Requires: embedlite-components-qt5 >= 2.0.0
 Requires: libqofono-qt5-declarative >= 0.117
 
 %description

--- a/rpm/sailfish-components-webview.spec
+++ b/rpm/sailfish-components-webview.spec
@@ -1,3 +1,5 @@
+%global min_qtmozembed_version 1.56.0
+
 Name:    sailfish-components-webview-qt5
 Summary: Allows embedding Sailfish WebView into applications
 Version: 1.7.0
@@ -10,11 +12,12 @@ BuildRequires:  pkgconfig(Qt5DBus)
 BuildRequires:  pkgconfig(Qt5Network)
 BuildRequires:  pkgconfig(Qt5Qml)
 BuildRequires:  pkgconfig(Qt5Quick)
-BuildRequires:  pkgconfig(qt5embedwidget) >= 1.52.20
+BuildRequires:  pkgconfig(qt5embedwidget) >= %{min_qtmozembed_version}
 BuildRequires:  pkgconfig(sailfishsilica)
 BuildRequires:  qt5-qttools
 BuildRequires:  qt5-qttools-linguist
 Requires: sailfishsilica-qt5 >= 1.1.123
+Requires: qtmozembed-qt5 >= %{min_qtmozembed_version}
 Requires: sailfish-components-media-qt5
 Requires: sailfish-components-pickers-qt5
 Requires: embedlite-components-qt5 >= 2.0.0

--- a/rpm/sailfish-components-webview.spec
+++ b/rpm/sailfish-components-webview.spec
@@ -108,6 +108,7 @@ BuildRequires:  qt5-tools
 %{_libdir}/qt5/qml/Sailfish/WebView/qmldir
 %{_libdir}/qt5/qml/Sailfish/WebView/plugins.qmltypes
 %{_libdir}/qt5/qml/Sailfish/WebView/*.qml
+%{_libdir}/qt5/qml/Sailfish/WebView/*.js
 %{_libdir}/qt5/qml/Sailfish/WebView/Controls/libsailfishwebviewcontrolsplugin.so
 %{_libdir}/qt5/qml/Sailfish/WebView/Controls/qmldir
 %{_libdir}/qt5/qml/Sailfish/WebView/Controls/plugins.qmltypes


### PR DESCRIPTION
- Adapt WebView settings and renderer preferences for the ESR115 stack.
- Forward safe-area insets and handle unavailable Gecko scroll metrics.
- Add Sailfish color picker handling and hide unavailable auth remember controls.
- Apply Sailfish text size settings to WebView content.
- Stop WebView embedding before application quit to avoid Gecko shutdown crashes.